### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ jobs:
 ```
 
 If you plan on having a different repository host your wiki
-directory, you're going to need a Personal Access Token instead of the `GITHUB_TOKEN`
+directory, you're going to need a Personal Access Token instead of the `GH_TOKEN`
 with the minimal scopes [seen here.](https://github.com/settings/tokens/new?scopes=repo&description=wiki%20page%20creator%20token)
 
 ---
@@ -78,7 +78,7 @@ with the minimal scopes [seen here.](https://github.com/settings/tokens/new?scop
 | Argument | Required | Default value | Description |
 |----------|----------|---------------|-------------|
 | WIKI_DIR | No | wiki/ | Directory to rsync files to the wiki.(https://github.com/settings/tokens/new?scopes=repo). |
-| GH_TOKEN | Yes | | The GitHub Token for this action to use. Specify `${{ secrets.GITHUB_TOKEN }}`. |
+| GH_TOKEN | Yes | | The GitHub Token for this action to use. Specify `${{ secrets.GH_TOKEN }}`. |
 | GH_MAIL | Yes | | The email associated with the token. |
 | GH_NAME | Yes | | The username associated with the token. |
 | EXCLUDED_FILES | No | | The files or directories you want to exclude. Note, we use rsync |

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ jobs:
         # Make sure you have that / at the end. We use rsync 
         # WIKI_DIR's default is wiki/
         WIKI_DIR: wiki/
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.GH_TOKEN }}
         GH_MAIL: ${{ secrets.YOUR_EMAIL }}
         GH_NAME: ${{ github.repository_owner }}
         EXCLUDED_FILES: "a/ b.md"


### PR DESCRIPTION
Fixed invalid repository secret name

## Description

The secret name GITHUB_TOKEN in the sample configuration file is not valid. When trying to create a secret with this name, the error "Failed to add secret. Name is invalid" appears.

[More](https://docs.github.com/en/actions/reference/encrypted-secrets#naming-your-secrets) about secrets names.

