### PR TITLE
Revert extreme use of "real" tests in favor of dry-run & real tests

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -46,7 +46,7 @@ jobs:
           strategy: init
           dry-run: true
   test-action-real:
-    concurrency: ${{ github.workflow }}
+    concurrency: ${{ github.workflow }}-real
     permissions:
       contents: write
     runs-on: ubuntu-latest

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -17,11 +17,11 @@ on:
       - README.md
       - .github/**
       - "!.github/workflows/test-action.yml"
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
 jobs:
-  test-action-clone:
-    concurrency: ${{ github.workflow }}
-    permissions:
-      contents: write
+  test-action-clone-dry-run:
     strategy:
       fail-fast: false
       matrix:
@@ -30,10 +30,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./
-  test-action-init:
-    concurrency: ${{ github.workflow }}
-    permissions:
-      contents: write
+        with:
+          strategy: clone
+          dry-run: true
+  test-action-init-dry-run:
     strategy:
       fail-fast: false
       matrix:
@@ -44,3 +44,12 @@ jobs:
       - uses: ./
         with:
           strategy: init
+          dry-run: true
+  test-action-real:
+    concurrency: ${{ github.workflow }}
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./


### PR DESCRIPTION
This PR would...
- Still run "real" tests ONCE per each PR invokation
- Run 6 dry-run tests like before
- Not lock up for like 20 minutes just to complete _one test cycle_ 😅