### PR TITLE
Fix "disable-empty-commits"

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -96,7 +96,7 @@ if (core.getBooleanInput("disable_empty_commits")) {
   try {
     await $`git commit -m ${core.getInput("commit_message")}`;
   } catch (e) {
-    if (e.exitCode === 1 && e.stderr.includes("nothing to commit")) {
+    if (e.exitCode === 1 && e.stdout.includes("nothing to commit")) {
       console.log("nothing to commit, working tree clean");
     } else {
       throw e; // Unexpected error


### PR DESCRIPTION
Follow up on #81

The action would still exit with a failure, even when the exception was supposed to be caught.

A strategically placed `console.log(e, JSON.stringify(e));` shows that the error message doesn't actually go to `stderr`, but to `stdout`, so now things should work correctly.

