### PR TITLE
Pin Deno@2.8.3 to avoid getting 404 on ARM64 linux runners

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -23,6 +23,19 @@ core.startGroup("process.env");
 console.table(process.env);
 core.endGroup();
 
+const isProcessError = (
+  err: unknown,
+): err is { exitCode: number; stdout: string } => {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "exitCode" in err &&
+    typeof err.exitCode === "number" &&
+    "stdout" in err &&
+    typeof err.stdout === "string"
+  );
+};
+
 const serverURL = core.getInput("github_server_url");
 const repo = core.getInput("repository");
 const wikiGitURL = `${serverURL}/${repo}.wiki.git`;
@@ -115,12 +128,16 @@ await $`git add -Av`;
 if (core.getBooleanInput("disable_empty_commits")) {
   try {
     await $`git commit -m ${core.getInput("commit_message")}`;
-  } catch (e) {
-    if (e.exitCode === 1 && e.stdout.includes("nothing to commit")) {
-      console.log("nothing to commit, working tree clean");
-    } else {
+  } catch (e: unknown) {
+    if (
+      !isProcessError(e) ||
+      e.exitCode !== 1 ||
+      !e.stdout.includes("nothing to commit")
+    ) {
       throw e; // Unexpected error
     }
+
+    console.log("nothing to commit, working tree clean");
   }
 } else {
   await $`git commit --allow-empty -m ${core.getInput("commit_message")}`;

--- a/cliw
+++ b/cliw
@@ -22,7 +22,7 @@ chronic() (
 if [ ! -d "$deno_dir" ]; then
   # https://github.com/denoland/deno_install#readme
   export DENO_INSTALL=$deno_dir
-  curl -fsSL https://deno.land/x/install/install.sh | chronic sh -s "v1.35.1"
+  curl -fsSL https://deno.land/install.sh | chronic sh -s "v2.8.3"
 fi
 
 # https://github.com/denoland/deno_install/blob/master/install.sh#L53


### PR DESCRIPTION
The current download link returns a 404 error due to a lack of ARM64 support in Deno. They were first introduced in [v1.41.0](https://deno.com/blog/v1.41).