### PR TITLE
Fix wiki wipe under Deno 2 (zx cwd-sync hook) and revamp tests

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -23,6 +23,21 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
 jobs:
+  # Integration tests: run cli.ts against local file:// wiki remotes and
+  # verify the exact resulting wiki contents (adds, deletes, nested syncs,
+  # initial setup, preprocessing). Uses the same Deno version that cliw pins.
+  test-cli:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.8.3
+      - run: deno test -A tests/cli.test.ts
   test-action-clone-dry-run:
     strategy:
       fail-fast: false
@@ -30,7 +45,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./
         with:
           strategy: clone
@@ -42,7 +57,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./
         with:
           strategy: init
@@ -55,7 +70,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./
         with:
           strategy: clone
@@ -69,17 +84,35 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./
         with:
           strategy: init
           dry-run: true
           disable-empty-commits: true
   test-action-real:
+    # Pushes to this repository's actual wiki, then clones it back and
+    # verifies the pushed contents match the wiki/ source directory.
+    # Skipped for fork PRs, which have a read-only token.
+    if: >-
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     concurrency: ${{ github.workflow }}-real
     permissions:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./
+      - name: Verify pushed wiki contents
+        run: |
+          set -eux
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.wiki.git" /tmp/wiki-verify
+          # README.md is renamed to Home.md by the preprocess step; every
+          # other file must match the wiki/ source tree exactly by name.
+          diff \
+            <(cd wiki && find . -type f | sed 's|^\./||; s|^README\.md$|Home.md|' | sort) \
+            <(cd /tmp/wiki-verify && find . -name .git -prune -o -type f -print | sed 's|^\./||' | sort)
+          test -s /tmp/wiki-verify/Home.md
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/cli.ts
+++ b/cli.ts
@@ -14,7 +14,7 @@ import { existsSync } from "node:fs";
 import { copy } from "npm:fs-extra@^11.1.1";
 import * as core from "npm:@actions/core@^1.10.0";
 import { temporaryDirectory } from "npm:tempy@^3.1.0";
-import { $ } from "npm:zx@^7.2.2";
+import { $, cd } from "npm:zx@^7.2.2";
 import { remark } from "npm:remark@^14.0.3";
 import { visit } from "npm:unist-util-visit@^5.0.0";
 import { basename, resolve } from "node:path";
@@ -41,7 +41,12 @@ const repo = core.getInput("repository");
 const wikiGitURL = `${serverURL}/${repo}.wiki.git`;
 const workspacePath = process.cwd();
 const d = temporaryDirectory();
-process.chdir(d);
+// zx's cd() instead of process.chdir(): zx >=7.2 keeps process.cwd() pinned
+// to its own snapshot via an AsyncHook, silently reverting a bare
+// process.chdir() after every `await $` (see issue #90). cd() updates that
+// snapshot. All fs calls below still use paths anchored at `d` so nothing
+// depends on the process cwd.
+cd(d);
 $.cwd = d;
 
 process.env.GH_TOKEN = core.getInput("token");
@@ -49,7 +54,7 @@ process.env.GH_HOST = new URL(core.getInput("github_server_url")).host;
 await $`gh auth setup-git`;
 
 if (core.getInput("strategy") === "clone") {
-  await $`git config --global --add safe.directory ${process.cwd()}`;
+  await $`git config --global --add safe.directory ${d}`;
   await $`git clone ${wikiGitURL} .`;
 } else if (core.getInput("strategy") === "init") {
   await $`git init -b master`;
@@ -65,7 +70,7 @@ await $`git config user.email 41898282+github-actions[bot]@users.noreply.github.
 await $`git config --global user.name github-actions[bot]`;
 await $`git config --global user.email 41898282+github-actions[bot]@users.noreply.github.com`;
 
-await appendFile(".git/info/exclude", core.getInput("ignore"));
+await appendFile(resolve(d, ".git/info/exclude"), core.getInput("ignore"));
 
 // Remove all files/dirs (except .git) from the wiki clone so that files
 // deleted from the source wiki directory are also removed in the wiki repo.
@@ -77,7 +82,7 @@ await Promise.all(
 
 await copy(
   resolve(workspacePath, core.getInput("path")),
-  process.cwd(),
+  d,
   {
     filter: (src) => {
       return basename(src) !== ".git";
@@ -87,8 +92,8 @@ await copy(
 
 if (core.getBooleanInput("preprocess")) {
   // https://github.com/nodejs/node/issues/39960
-  if (existsSync("README.md")) {
-    await rename("README.md", "Home.md");
+  if (existsSync(resolve(d, "README.md"))) {
+    await rename(resolve(d, "README.md"), resolve(d, "Home.md"));
     console.log("Moved README.md to Home.md");
   }
 
@@ -113,14 +118,14 @@ if (core.getBooleanInput("preprocess")) {
 
       console.log(`Rewrote ${x} to ${node.url}`);
     });
-  for (const file of await readdir($.cwd!)) {
+  for (const file of await readdir(d)) {
     if (!mdRe.test(file)) {
       continue;
     }
 
-    let md = await readFile(file, "utf-8");
+    let md = await readFile(resolve(d, file), "utf-8");
     md = (await remark().use(plugin).process(md)).toString();
-    await writeFile(file, md);
+    await writeFile(resolve(d, file), md);
   }
 }
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,0 +1,293 @@
+// Integration tests for cli.ts.
+//
+// Each test builds a fake "GitHub wiki" as a local bare git repo, a fake
+// workspace (a git checkout containing a wiki/ source directory), runs
+// cli.ts as a subprocess against them via a file:// remote, and then
+// verifies the exact file tree and contents that ended up in the wiki repo.
+//
+// Run with: deno test -A tests/cli.test.ts
+import { assertEquals } from "jsr:@std/assert@^1.0.0";
+import { delimiter, dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const CLI_PATH = fileURLToPath(new URL("../cli.ts", import.meta.url));
+const REPO = "test/test";
+
+async function git(cwd: string, ...args: string[]): Promise<string> {
+  const out = await new Deno.Command("git", {
+    args,
+    cwd,
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+  if (!out.success) {
+    throw new Error(
+      `git ${args.join(" ")} failed:\n${new TextDecoder().decode(out.stderr)}`,
+    );
+  }
+  return new TextDecoder().decode(out.stdout).trim();
+}
+
+async function writeFiles(root: string, files: Record<string, string>) {
+  for (const [rel, content] of Object.entries(files)) {
+    const path = join(root, ...rel.split("/"));
+    await Deno.mkdir(dirname(path), { recursive: true });
+    await Deno.writeTextFile(path, content);
+  }
+}
+
+interface Scenario {
+  strategy?: "clone" | "init";
+  /** Pre-existing wiki contents; "empty" = wiki repo exists but has no commits. */
+  remote: Record<string, string> | "empty";
+  /** Contents of the workspace's wiki/ source directory. */
+  workspaceWiki: Record<string, string>;
+  /** Exact expected wiki repo contents after the action runs. */
+  expect: Record<string, string>;
+  preprocess?: boolean;
+}
+
+async function runScenario(scenario: Scenario): Promise<void> {
+  const root = await Deno.makeTempDir({ prefix: "wiki-action-test-" });
+  try {
+    // 1. Fake remote: a bare repo laid out so that
+    //    `${server-url}/${repository}.wiki.git` resolves to it.
+    const bare = join(root, "remote", ...`${REPO}.wiki.git`.split("/"));
+    await Deno.mkdir(bare, { recursive: true });
+    await git(bare, "init", "--bare", "-q");
+    // GitHub wikis live on master; make the empty-repo case match too.
+    await git(bare, "symbolic-ref", "HEAD", "refs/heads/master");
+    if (scenario.remote !== "empty") {
+      const seed = join(root, "seed");
+      await Deno.mkdir(seed);
+      await git(seed, "init", "-q", "-b", "master");
+      await writeFiles(seed, scenario.remote);
+      await git(seed, "add", "-A");
+      await git(
+        seed,
+        "-c", "user.email=seed@example.com",
+        "-c", "user.name=seed",
+        "commit", "-qm", "existing wiki content",
+      );
+      await git(seed, "push", "-q", bare, "master");
+    }
+
+    // 2. Fake workspace: a git checkout (like actions/checkout) with the
+    //    wiki source under wiki/.
+    const workspace = join(root, "workspace");
+    await Deno.mkdir(join(workspace, "wiki"), { recursive: true });
+    await writeFiles(join(workspace, "wiki"), scenario.workspaceWiki);
+    await git(workspace, "init", "-q", "-b", "main");
+    await git(workspace, "add", "-A");
+    await git(
+      workspace,
+      "-c", "user.email=ws@example.com",
+      "-c", "user.name=ws",
+      "commit", "-qm", "workspace",
+    );
+
+    // 3. Stub `gh` so `gh auth setup-git` is a no-op (file:// needs no auth).
+    const bin = join(root, "bin");
+    await Deno.mkdir(bin);
+    await Deno.writeTextFile(join(bin, "gh"), "#!/bin/sh\nexit 0\n");
+    if (Deno.build.os === "windows") {
+      await Deno.writeTextFile(join(bin, "gh.cmd"), "@echo off\r\nexit /b 0\r\n");
+    } else {
+      await Deno.chmod(join(bin, "gh"), 0o755);
+    }
+
+    // 4. Isolated HOME so the cli's `git config --global` writes stay here.
+    const home = join(root, "home");
+    await Deno.mkdir(home);
+
+    const env: Record<string, string> = { ...Deno.env.toObject() };
+    for (const key of Object.keys(env)) {
+      if (key.toUpperCase() === "PATH") delete env[key];
+    }
+    env.PATH = bin + delimiter + (Deno.env.get("PATH") ?? "");
+    env.HOME = home;
+    env.USERPROFILE = home;
+    env.XDG_CONFIG_HOME = join(home, ".config");
+    env.INPUT_STRATEGY = scenario.strategy ?? "clone";
+    env.INPUT_REPOSITORY = REPO;
+    env.INPUT_GITHUB_SERVER_URL = pathToFileURL(join(root, "remote")).href;
+    env.INPUT_TOKEN = "test-token";
+    env.INPUT_PATH = "wiki";
+    env.INPUT_COMMIT_MESSAGE = "test commit";
+    env.INPUT_IGNORE = "";
+    env.INPUT_DRY_RUN = "false";
+    env.INPUT_PREPROCESS = String(scenario.preprocess ?? true);
+    env.INPUT_DISABLE_EMPTY_COMMITS = "false";
+
+    const out = await new Deno.Command(Deno.execPath(), {
+      args: ["run", "-A", CLI_PATH],
+      cwd: workspace,
+      env,
+      clearEnv: true,
+      stdout: "piped",
+      stderr: "piped",
+    }).output();
+    if (!out.success) {
+      throw new Error(
+        "cli.ts failed\n--- stdout ---\n" +
+          new TextDecoder().decode(out.stdout) +
+          "\n--- stderr ---\n" +
+          new TextDecoder().decode(out.stderr),
+      );
+    }
+
+    // 5. Verify the wiki repo now contains exactly the expected files.
+    const tree = (await git(bare, "ls-tree", "-r", "--name-only", "master"))
+      .split("\n")
+      .filter(Boolean)
+      .sort();
+    assertEquals(tree, Object.keys(scenario.expect).sort());
+    for (const [path, content] of Object.entries(scenario.expect)) {
+      assertEquals(
+        await git(bare, "show", `master:${path}`),
+        content.trim(),
+        `content mismatch for ${path}`,
+      );
+    }
+
+    // 6. Verify the workspace was not polluted (regression check for #90,
+    //    where wiki files were copied into the workspace instead of the
+    //    wiki clone).
+    const workspaceEntries = [...Deno.readDirSync(workspace)]
+      .map((e) => e.name)
+      .sort();
+    assertEquals(workspaceEntries, [".git", "wiki"]);
+  } finally {
+    await Deno.remove(root, { recursive: true }).catch(() => {});
+  }
+}
+
+Deno.test("adds new files to an existing wiki", () =>
+  runScenario({
+    remote: { "Home.md": "old home" },
+    workspaceWiki: {
+      "Home.md": "updated home",
+      "Usage.md": "how to use this project",
+    },
+    expect: {
+      "Home.md": "updated home",
+      "Usage.md": "how to use this project",
+    },
+  }));
+
+Deno.test("works when the source has no Home.md", () =>
+  runScenario({
+    remote: { "Home.md": "default page" },
+    workspaceWiki: {
+      "Setup.md": "setup instructions",
+      "Usage.md": "usage instructions",
+    },
+    expect: {
+      "Setup.md": "setup instructions",
+      "Usage.md": "usage instructions",
+    },
+  }));
+
+Deno.test("removes files deleted from the source", () =>
+  runScenario({
+    remote: {
+      "Home.md": "home",
+      "Old-Page.md": "obsolete",
+      "Deprecated.md": "obsolete too",
+    },
+    workspaceWiki: { "Home.md": "home" },
+    expect: { "Home.md": "home" },
+  }));
+
+Deno.test("syncs adds and deletes in subdirectories 4 levels deep", () =>
+  runScenario({
+    remote: {
+      "Home.md": "home",
+      "docs/a.md": "a",
+      "docs/api/b.md": "b",
+      "docs/api/v1/c.md": "c",
+      "docs/api/v1/internal/d.md": "d",
+      "stale/gone.md": "should be deleted",
+    },
+    workspaceWiki: {
+      "Home.md": "home v2",
+      "docs/a.md": "a",
+      "docs/api/v1/internal/d.md": "d v2",
+      "docs/api/v1/internal/new-leaf.md": "new file 4 levels deep",
+      "brand/new/deep/tree/leaf.md": "new subtree 4 levels deep",
+    },
+    expect: {
+      "Home.md": "home v2",
+      "docs/a.md": "a",
+      "docs/api/v1/internal/d.md": "d v2",
+      "docs/api/v1/internal/new-leaf.md": "new file 4 levels deep",
+      "brand/new/deep/tree/leaf.md": "new subtree 4 levels deep",
+    },
+  }));
+
+// When the wiki is first enabled, GitHub seeds it with its own Home.md (and
+// people may have edited it in the UI since), so the wiki starts completely
+// mis-synced with the source tree. The first sync must fully replace it.
+Deno.test("initial setup: replaces a completely mis-synced wiki (clone strategy)", () =>
+  runScenario({
+    strategy: "clone",
+    remote: {
+      "Home.md": "Welcome to the wiki!",
+      "Random-Notes.md": "created in the web UI",
+      "scratch/ideas.md": "more UI-created content",
+    },
+    workspaceWiki: {
+      "Home.md": "real home",
+      "Getting-Started.md": "getting started",
+      "guides/install/steps/advanced/tuning.md": "deep guide",
+    },
+    expect: {
+      "Home.md": "real home",
+      "Getting-Started.md": "getting started",
+      "guides/install/steps/advanced/tuning.md": "deep guide",
+    },
+  }));
+
+Deno.test("initial setup: replaces a completely mis-synced wiki (init strategy)", () =>
+  runScenario({
+    strategy: "init",
+    remote: {
+      "Home.md": "Welcome to the wiki!",
+      "Random-Notes.md": "created in the web UI",
+    },
+    workspaceWiki: {
+      "Home.md": "real home",
+      "Getting-Started.md": "getting started",
+    },
+    expect: {
+      "Home.md": "real home",
+      "Getting-Started.md": "getting started",
+    },
+  }));
+
+Deno.test("initial setup: first push to an empty wiki repository", () =>
+  runScenario({
+    remote: "empty",
+    workspaceWiki: {
+      "Home.md": "first ever home",
+      "guides/setup.md": "setup guide",
+    },
+    expect: {
+      "Home.md": "first ever home",
+      "guides/setup.md": "setup guide",
+    },
+  }));
+
+Deno.test("preprocess renames README.md to Home.md and rewrites .md links", () =>
+  runScenario({
+    preprocess: true,
+    remote: { "Home.md": "old" },
+    workspaceWiki: {
+      "README.md": "# Title\n\n[Usage](Usage.md)\n",
+      "Usage.md": "usage",
+    },
+    expect: {
+      "Home.md": "# Title\n\n[Usage](Usage)",
+      "Usage.md": "usage",
+    },
+  }));


### PR DESCRIPTION
Fixes #90

## Root cause

The only functional change in v5.0.5 was pinning Deno 1.35.1 → 2.8.3. That upgrade activated a landmine in zx 7.2.4: zx registers a Node **AsyncHook** (`syncCwd` in its `core.js`) that on every async transition forcibly `process.chdir()`s back to the cwd snapshotted at import time. Under Deno 1.x async hooks were unimplemented stubs, so the hook never fired; Deno 2 implements them, so the script's `process.chdir(tempDir)` was silently reverted after the first `await $` command.

Fallout in `cli.ts`:

- git commands still ran in the temp wiki clone (via `$.cwd`), and the "remove everything except `.git`" step still wiped it (absolute paths)
- but `copy()` targeted `process.cwd()`, which had snapped back to the **workspace**
- so the clone stayed empty and `git add -Av` + force-push published a commit deleting every wiki page

Reproduced end-to-end locally: an identical setup pushes a zero-file commit under Deno 2.8.3 and a correct sync under Deno 1.35.1.

## Fix

- Use zx's `cd(d)` instead of `process.chdir(d)`, which updates zx's internal cwd snapshot so the hook stops fighting us
- Anchor every fs operation (`.git/info/exclude` append, `copy()` target, preprocess rename/read/write, `safe.directory`) at the temp dir, so nothing depends on the process cwd at all

## Test revamp

New `tests/cli.test.ts`: 8 integration tests that run `cli.ts` as a subprocess against a local bare git repo posing as the wiki (`file://` server URL, stubbed `gh`, isolated `HOME`), then assert the **exact** resulting wiki tree and file contents, plus that the workspace wasn't polluted (a direct regression guard for #90):

- adding files to an existing wiki
- source with no `Home.md`
- removing files deleted from the source
- add + delete syncs in subdirectories 4 levels deep
- initial setup: completely mis-synced wiki (both `clone` and `init` strategies)
- initial setup: first push to an empty wiki repository
- `README.md` → `Home.md` preprocessing with `.md` link rewriting

The suite **fails against the v5.0.5 code** and passes with the fix.

CI changes: new `test-cli` job running the suite on ubuntu/windows/macos with the same Deno v2.8.3 that `cliw` pins; `test-action-real` now clones the wiki back after pushing and diffs it against the `wiki/` source dir (and is gated to skip fork PRs, whose tokens can't push anyway); checkout bumped to v4.

## Release note

When cutting 5.0.6, consider also moving the `v5` tag (it currently points at v5.0.4) and yanking or annotating the v5.0.5 release, since it deletes wikis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WE9xyekNMC7KAz4eWLkqav