### PR TITLE
Add repo-file blob links and direction: pull wiki sync

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -33,7 +33,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: denoland/setup-deno@v2
         with:
           deno-version: v2.8.3
@@ -45,7 +45,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./
         with:
           strategy: clone
@@ -57,7 +57,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./
         with:
           strategy: init
@@ -70,7 +70,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./
         with:
           strategy: clone
@@ -84,39 +84,18 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./
         with:
           strategy: init
           dry-run: true
           disable-empty-commits: true
-  test-action-pull:
-    # Pulls the repository's actual wiki back into the workspace (writes only
-    # to the runner's checkout; nothing is committed or pushed anywhere).
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./
-        with:
-          direction: pull
-      - name: Verify pulled wiki contents
-        shell: bash
-        run: |
-          set -eux
-          # The push preprocess renames README.md to Home.md; the pull must
-          # invert it.
-          test -s wiki/README.md
-          test ! -f wiki/Home.md
-          # Bare wiki page links must get their .md extension back.
-          grep -F "(./another-page.md)" wiki/README.md
-  test-action-real:
-    # Pushes to this repository's actual wiki, then clones it back and
-    # verifies the pushed contents match the wiki/ source directory.
-    # Skipped for fork PRs, which have a read-only token.
+  test-e2e:
+    # Live end-to-end tests (tests/e2e.test.ts): pushes wiki/ to this
+    # repository's actual wiki, verifies the published pages over HTTP
+    # (every Home page link must resolve on github.com), then pulls the
+    # wiki back and verifies the inverse transforms. Skipped for fork PRs,
+    # which have a read-only token.
     if: >-
       github.event_name == 'push' ||
       github.event.pull_request.head.repo.full_name == github.repository
@@ -125,17 +104,10 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: ./
-      - name: Verify pushed wiki contents
-        run: |
-          set -eux
-          git clone "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.wiki.git" /tmp/wiki-verify
-          # README.md is renamed to Home.md by the preprocess step; every
-          # other file must match the wiki/ source tree exactly by name.
-          diff \
-            <(cd wiki && find . -type f | sed 's|^\./||; s|^README\.md$|Home.md|' | sort) \
-            <(cd /tmp/wiki-verify && find . -name .git -prune -o -type f -print | sed 's|^\./||' | sort)
-          test -s /tmp/wiki-verify/Home.md
+      - uses: actions/checkout@v7
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.8.3
+      - run: deno test -A tests/e2e.test.ts
         env:
-          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -90,6 +90,29 @@ jobs:
           strategy: init
           dry-run: true
           disable-empty-commits: true
+  test-action-pull:
+    # Pulls the repository's actual wiki back into the workspace (writes only
+    # to the runner's checkout; nothing is committed or pushed anywhere).
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./
+        with:
+          direction: pull
+      - name: Verify pulled wiki contents
+        shell: bash
+        run: |
+          set -eux
+          # The push preprocess renames README.md to Home.md; the pull must
+          # invert it.
+          test -s wiki/README.md
+          test ! -f wiki/Home.md
+          # Bare wiki page links must get their .md extension back.
+          grep -F "(./another-page.md)" wiki/README.md
   test-action-real:
     # Pushes to this repository's actual wiki, then clones it back and
     # verifies the pushed contents match the wiki/ source directory.

--- a/.github/workflows/update-tags.yml
+++ b/.github/workflows/update-tags.yml
@@ -13,6 +13,6 @@ jobs:
   update-tags:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/publish-action@v0.2.2
+      - uses: actions/publish-action@v0.4.0
         with:
           source-tag: ${{ github.event.release.tag_name }}

--- a/README.md
+++ b/README.md
@@ -121,7 +121,9 @@ is specific to GitHub wikis.
   testing.
 
 - **`preprocess`:** If this option is true, we will preprocess the wiki to move
-  the `README.md` to `Home.md` as well as rewriting all `.md` links to be bare
+  the `README.md` to `Home.md` as well as rewriting links to wiki pages to be
+  bare links. Link targets in any markup format GitHub renders (`.md`, `.rst`,
+  `.adoc`, ...) are recognized, though only Markdown files are parsed for
   links. Relative links that point at other files in your repository (a script,
   a source file, a Markdown file outside the wiki folder) are rewritten to full
   `blob/` view URLs pinned to the pushed commit, the same way GitHub resolves

--- a/README.md
+++ b/README.md
@@ -78,6 +78,15 @@ is specific to GitHub wikis.
 
 ### Inputs
 
+- **`direction`:** Select from `push` or `pull`. `push` (the default) syncs the
+  `path` folder to the GitHub wiki. `pull` does the reverse: it clones the
+  wiki, converts the pages back into source-friendly Markdown (`Home.md`
+  becomes `README.md` and bare wiki page links get their `.md` extension back),
+  and mirrors them into the `path` folder of your workspace. Nothing is
+  committed or pushed to your repository in pull mode; pair it with a
+  PR-creating action like [create-pull-request]. See
+  [Pulling wiki edits back](#pulling-wiki-edits-back) below.
+
 - **`strategy`:** Select from `clone` or `init` to determine which method to use
   to push changes to the GitHub wiki. `clone` will clone the `.wiki.git` repo
   and add an additional commit. `init` will create a new repo with a single
@@ -113,8 +122,11 @@ is specific to GitHub wikis.
 
 - **`preprocess`:** If this option is true, we will preprocess the wiki to move
   the `README.md` to `Home.md` as well as rewriting all `.md` links to be bare
-  links. This helps ensure that the Markdown works in source control as well as
-  the wiki. The default is true.
+  links. Relative links that point at other files in your repository (a script,
+  a source file, a Markdown file outside the wiki folder) are rewritten to full
+  `blob/` view URLs pinned to the pushed commit, the same way GitHub resolves
+  them when rendering in-repo Markdown. This helps ensure that the Markdown
+  works in source control as well as the wiki. The default is true.
 
 - **`disable-empty-commits`:** By default, any triggering of this action will
   result in a commit to the Wiki, even if that commit is empty.
@@ -142,6 +154,39 @@ than the default `strategy: clone`.
 - **`wiki_url`:** The HTTP URL that points to the deployed repository's wiki
   tab. This is essentially the concatenation of `${{ github.server_url }}`,
   `${{ github.repository }}`, and the `/wiki` page.
+
+### Pulling wiki edits back
+
+If someone edits a page in the wiki UI, those edits normally get overwritten by
+the next push from your `wiki/` folder. `direction: pull` lets you sync them
+back into your source tree instead. It clones the wiki, applies the inverse of
+the `preprocess` transformations (`Home.md` ➡ `README.md`, `./page` ➡
+`./page.md`), and updates the `path` folder in your workspace. It never
+commits or pushes to your repository, so combine it with something like
+[create-pull-request] to open a docs PR:
+
+```yml
+name: Pull wiki
+on:
+  gollum: # Runs whenever a wiki page is created or edited
+  workflow_dispatch:
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  pull-wiki:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Andrew-Chen-Wang/github-wiki-action@v4
+        with:
+          direction: pull
+      - uses: peter-evans/create-pull-request@v6
+        with:
+          branch: sync-wiki
+          title: Sync wiki edits back into wiki/
+          commit-message: Sync wiki edits back into wiki/
+```
 
 ### Cross-repo wikis
 
@@ -195,6 +240,7 @@ between your IDE and the PR, but it's the easiest way to test the action.
 
 <!-- prettier-ignore-start -->
 [Decathlon/wiki-page-creator-action#11]: https://github.com/Decathlon/wiki-page-creator-action/issues/11
+[create-pull-request]: https://github.com/peter-evans/create-pull-request
 [supported markup languages]: https://github.com/github/markup#markups
 [PAT]: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
 <!-- prettier-ignore-end -->

--- a/README.md
+++ b/README.md
@@ -80,11 +80,12 @@ is specific to GitHub wikis.
 
 - **`direction`:** Select from `push` or `pull`. `push` (the default) syncs the
   `path` folder to the GitHub wiki. `pull` does the reverse: it clones the
-  wiki, converts the pages back into source-friendly Markdown (`Home.md`
-  becomes `README.md` and bare wiki page links get their `.md` extension back),
-  and mirrors them into the `path` folder of your workspace. Nothing is
-  committed or pushed to your repository in pull mode; pair it with a
-  PR-creating action like [create-pull-request]. See
+  wiki, converts the pages back into source-friendly form (`Home.md` becomes
+  `README.md` and bare wiki page links get the extension of the page they
+  target back), and mirrors them into the `path` folder of your workspace. The
+  `ignore` input is not applied in pull mode. Nothing is committed or pushed
+  to your repository in pull mode; pair it with a PR-creating action like
+  [create-pull-request]. See
   [Pulling wiki edits back](#pulling-wiki-edits-back) below.
 
 - **`strategy`:** Select from `clone` or `init` to determine which method to use
@@ -134,6 +135,16 @@ is specific to GitHub wikis.
   result in a commit to the Wiki, even if that commit is empty.
   If this option is true, a workflow run which would result in no changes
   to the Wiki files, will no longer create an empty commit. The default is false.
+
+#### `preprocess:` limitations
+
+- Only Markdown pages at the top level of the `path` folder have their links
+  rewritten; pages in subdirectories and non-Markdown pages are synced
+  verbatim.
+- Inline links are rewritten; reference-style link definitions
+  (`[label]: ./page.md`) and image links are not.
+- A page whose name itself ends in a renderable extension (say a page called
+  `example.org`) is treated as a file link rather than a page link.
 
 #### `strategy:` input
 

--- a/README.md
+++ b/README.md
@@ -127,22 +127,27 @@ is specific to GitHub wikis.
   `.adoc`, ...) are recognized, though only Markdown files are parsed for
   links. Relative links that point at other files in your repository (a script,
   a source file, a Markdown file outside the wiki folder) are rewritten to full
-  `blob/` view URLs pinned to the pushed commit, the same way GitHub resolves
-  them when rendering in-repo Markdown. This helps ensure that the Markdown
-  works in source control as well as the wiki. The default is true.
+  `blob/` view URLs (`raw/` URLs for images) pinned to the pushed commit, the
+  same way GitHub resolves them when rendering in-repo Markdown. This helps
+  ensure that the Markdown works in source control as well as the wiki. The
+  default is true. See [`preprocess:` notes](#preprocess-notes).
 
 - **`disable-empty-commits`:** By default, any triggering of this action will
   result in a commit to the Wiki, even if that commit is empty.
   If this option is true, a workflow run which would result in no changes
   to the Wiki files, will no longer create an empty commit. The default is false.
 
-#### `preprocess:` limitations
+#### `preprocess:` notes
 
-- Only Markdown pages at the top level of the `path` folder have their links
-  rewritten; pages in subdirectories and non-Markdown pages are synced
-  verbatim.
-- Inline links are rewritten; reference-style link definitions
-  (`[label]: ./page.md`) and image links are not.
+- Only Markdown pages are parsed for links; pages in other formats (`.rst`,
+  `.adoc`, ...) are synced verbatim but still recognized as link targets.
+- GitHub serves wiki pages flat by basename, so cross-directory page links
+  are rewritten to bare page names, while same-directory links keep their
+  form. Reference-style definitions (`[label]: ./page.md`) are rewritten
+  like the links or images that use them.
+- Images pointing at repository files become `raw/` URLs (a `blob/` page
+  would not render inside an image); images shipped inside the wiki folder
+  stay relative.
 - A page whose name itself ends in a renderable extension (say a page called
   `example.org`) is treated as a file link rather than a page link.
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ jobs:
   publish-wiki:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: Andrew-Chen-Wang/github-wiki-action@v4
+      - uses: actions/checkout@v7
+      - uses: Andrew-Chen-Wang/github-wiki-action@v5
 ```
 
 ☝ This workflow will mirror the `wiki/` folder in your GitHub repository to the
@@ -177,11 +177,11 @@ jobs:
   pull-wiki:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: Andrew-Chen-Wang/github-wiki-action@v4
+      - uses: actions/checkout@v7
+      - uses: Andrew-Chen-Wang/github-wiki-action@v5
         with:
           direction: pull
-      - uses: peter-evans/create-pull-request@v6
+      - uses: peter-evans/create-pull-request@v8
         with:
           branch: sync-wiki
           title: Sync wiki edits back into wiki/
@@ -214,8 +214,8 @@ jobs:
   publish-wiki:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: Andrew-Chen-Wang/github-wiki-action@v4
+      - uses: actions/checkout@v7
+      - uses: Andrew-Chen-Wang/github-wiki-action@v5
         with:
           token: ${{ secrets.MEGA_PROJECT_GITHUB_TOKEN }}
           repository: octocat/mega-project

--- a/action.yml
+++ b/action.yml
@@ -12,11 +12,13 @@ inputs:
     description: >-
       Select from 'push' or 'pull'. 'push' (the default) syncs the path folder
       to the GitHub wiki. 'pull' does the reverse: it clones the wiki, converts
-      the pages back into source-friendly Markdown (Home.md becomes README.md
-      and bare wiki page links get their .md extension back when preprocess is
-      enabled), and mirrors them into the path folder of your workspace.
-      Nothing is committed or pushed to your repository in pull mode; pair it
-      with a PR-creating action like peter-evans/create-pull-request.
+      the pages back into source-friendly form (Home.md becomes README.md and
+      bare wiki page links get the extension of the page they target back,
+      in any markup format GitHub renders) when preprocess is enabled, and
+      mirrors them into the path folder of your workspace. The ignore input is
+      not applied in pull mode. Nothing is committed or pushed to your
+      repository in pull mode; pair it with a PR-creating action like
+      peter-evans/create-pull-request.
     required: true
     default: push
   strategy:

--- a/action.yml
+++ b/action.yml
@@ -82,9 +82,10 @@ inputs:
       to Home.md as well as rewriting links to wiki pages (in any markup format
       GitHub renders, like .md, .rst, or .adoc) to be bare links. Relative
       links that point to other files in your repository (like a script or
-      source file) are rewritten to full blob view URLs, mirroring how GitHub
-      renders in-repo Markdown. This helps ensure that the Markdown works in
-      source control as well as the wiki. The default is true.
+      source file) are rewritten to full blob view URLs (raw URLs for images),
+      mirroring how GitHub renders in-repo Markdown. This helps ensure that
+      the Markdown works in source control as well as the wiki. The default
+      is true.
     required: true
     default: true
   disable-empty-commits:

--- a/action.yml
+++ b/action.yml
@@ -77,7 +77,8 @@ inputs:
   preprocess:
     description: >-
       If this option is true, we will preprocess the wiki to move the README.md
-      to Home.md as well as rewriting all .md links to be bare links. Relative
+      to Home.md as well as rewriting links to wiki pages (in any markup format
+      GitHub renders, like .md, .rst, or .adoc) to be bare links. Relative
       links that point to other files in your repository (like a script or
       source file) are rewritten to full blob view URLs, mirroring how GitHub
       renders in-repo Markdown. This helps ensure that the Markdown works in

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,17 @@ branding:
   icon: book
   color: blue
 inputs:
+  direction:
+    description: >-
+      Select from 'push' or 'pull'. 'push' (the default) syncs the path folder
+      to the GitHub wiki. 'pull' does the reverse: it clones the wiki, converts
+      the pages back into source-friendly Markdown (Home.md becomes README.md
+      and bare wiki page links get their .md extension back when preprocess is
+      enabled), and mirrors them into the path folder of your workspace.
+      Nothing is committed or pushed to your repository in pull mode; pair it
+      with a PR-creating action like peter-evans/create-pull-request.
+    required: true
+    default: push
   strategy:
     description: >-
       Select from 'clone' or 'init' to determine which method to use to push
@@ -66,9 +77,11 @@ inputs:
   preprocess:
     description: >-
       If this option is true, we will preprocess the wiki to move the README.md
-      to Home.md as well as rewriting all .md links to be bare links. This helps
-      ensure that the Markdown works in source control as well as the wiki. The
-      default is true.
+      to Home.md as well as rewriting all .md links to be bare links. Relative
+      links that point to other files in your repository (like a script or
+      source file) are rewritten to full blob view URLs, mirroring how GitHub
+      renders in-repo Markdown. This helps ensure that the Markdown works in
+      source control as well as the wiki. The default is true.
     required: true
     default: true
   disable-empty-commits:
@@ -93,6 +106,7 @@ runs:
       run: '"${GITHUB_ACTION_PATH%/}/cliw"'
       shell: bash
       env:
+        INPUT_DIRECTION: ${{ inputs.direction }}
         INPUT_STRATEGY: ${{ inputs.strategy }}
         INPUT_REPOSITORY: ${{ inputs.repository }}
         INPUT_GITHUB_SERVER_URL: ${{ inputs.github-server-url }}

--- a/cli.ts
+++ b/cli.ts
@@ -17,7 +17,7 @@ import { temporaryDirectory } from "npm:tempy@^3.1.0";
 import { $, cd } from "npm:zx@^7.2.2";
 import { remark } from "npm:remark@^14.0.3";
 import { visit } from "npm:unist-util-visit@^5.0.0";
-import { basename, resolve } from "node:path";
+import { basename, join, relative, resolve, sep } from "node:path";
 
 core.startGroup("process.env");
 console.table(process.env);
@@ -52,6 +52,109 @@ $.cwd = d;
 process.env.GH_TOKEN = core.getInput("token");
 process.env.GH_HOST = new URL(core.getInput("github_server_url")).host;
 await $`gh auth setup-git`;
+
+// File extensions GitHub renders as Markdown pages.
+// https://github.com/github/markup
+const pageExtRe = /\.(?:md|markdown|mdown|mkdn|mkd|mdwn|mkdown|ron)$/;
+
+// URLs that are plain paths: no scheme (https:, mailto:, ...) and no //host.
+const isPathOnly = (url: string) =>
+  !/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(url) && !url.startsWith("//");
+
+// Splits "docs/a.md#frag" into ["docs/a.md", "#frag"].
+const splitPath = (url: string): [string, string] => {
+  const i = url.search(/[?#]/);
+  return i === -1 ? [url, ""] : [url.slice(0, i), url.slice(i)];
+};
+
+const decodePath = (path: string): string | undefined => {
+  try {
+    return decodeURIComponent(path);
+  } catch {
+    return undefined;
+  }
+};
+
+const contains = (parent: string, child: string) =>
+  child === parent || child.startsWith(parent + sep);
+
+// Rewrites link URLs in every top-level Markdown file in dir. rewrite()
+// returns the new URL, or undefined to leave the link untouched.
+async function rewriteLinks(
+  dir: string,
+  rewrite: (url: string) => string | undefined,
+) {
+  const plugin = () => (tree: any) =>
+    visit(tree, ["link", "linkReference"], (node: any) => {
+      if (typeof node.url !== "string" || !isPathOnly(node.url)) return;
+      const rewritten = rewrite(node.url);
+      if (rewritten == null || rewritten === node.url) return;
+      console.log(`Rewrote ${node.url} to ${rewritten}`);
+      node.url = rewritten;
+    });
+  for (const file of await readdir(dir)) {
+    if (!pageExtRe.test(file)) continue;
+    const path = resolve(dir, file);
+    const md = await readFile(path, "utf-8");
+    await writeFile(path, (await remark().use(plugin).process(md)).toString());
+  }
+}
+
+if (core.getInput("direction") === "pull") {
+  // Sync the wiki back into the source tree: the exact inverse of the push
+  // preprocess (issue #67). Clones the wiki, restores source-friendly
+  // Markdown (Home.md -> README.md, bare page links -> .md links), and
+  // mirrors it into the path folder. Nothing is committed or pushed; pair
+  // this with a PR-creating action.
+  await $`git config --global --add safe.directory ${d}`;
+  await $`git clone ${wikiGitURL} .`;
+
+  if (core.getBooleanInput("preprocess")) {
+    const hasHome = existsSync(resolve(d, "Home.md"));
+    await rewriteLinks(d, (url) => {
+      const [path, suffix] = splitPath(url);
+      if (!path || path.startsWith("/") || pageExtRe.test(path)) return;
+      const decoded = decodePath(path);
+      if (decoded === undefined) return;
+      const target = resolve(d, decoded);
+      if (!contains(d, target)) return;
+      if (hasHome && target === resolve(d, "Home")) {
+        return path.replace(/Home$/, "README") + ".md" + suffix;
+      }
+      if (existsSync(target + ".md")) return path + ".md" + suffix;
+      return;
+    });
+
+    if (hasHome) {
+      await rename(resolve(d, "Home.md"), resolve(d, "README.md"));
+      console.log("Moved Home.md to README.md");
+    }
+  }
+
+  const dest = resolve(workspacePath, core.getInput("path"));
+  if (core.getBooleanInput("dry_run")) {
+    console.log(`Would sync these wiki files to ${dest}:`);
+    await $`git ls-files`;
+  } else {
+    // Mirror semantics: files deleted from the wiki disappear from the
+    // destination too. Keep .git so path: '.' stays a valid checkout.
+    if (existsSync(dest)) {
+      await Promise.all(
+        (await readdir(dest))
+          .filter((entry) => entry !== ".git")
+          .map((entry) => rm(resolve(dest, entry), { recursive: true, force: true })),
+      );
+    }
+    await copy(d, dest, {
+      filter: (src) => {
+        return basename(src) !== ".git";
+      },
+    });
+  }
+
+  core.setOutput("wiki_url", `${serverURL}/${repo}/wiki`);
+  process.exit(0);
+}
 
 if (core.getInput("strategy") === "clone") {
   await $`git config --global --add safe.directory ${d}`;
@@ -97,36 +200,37 @@ if (core.getBooleanInput("preprocess")) {
     console.log("Moved README.md to Home.md");
   }
 
-  const mdRe = /\.(?:md|markdown|mdown|mkdn|mkd|mdwn|mkdown|ron)([:\/\?#\[\]@].*)?$/;
-  const plugin = () => (tree: any) =>
-    visit(tree, ["link", "linkReference"], (node: any) => {
-      const matches = node.url?.match(mdRe)
-      if (!matches) {
-        return;
-      }
-      if (!new URL(node.url, "file:///-/").href.startsWith("file:///-/")) {
-        return;
-      }
+  const sourceDir = resolve(workspacePath, core.getInput("path"));
+  // Links to source files point at the repo the workflow checked out, which
+  // is not necessarily the wiki's repo (cross-repo publishing).
+  const blobBase = `${process.env.GITHUB_SERVER_URL || serverURL}/${
+    process.env.GITHUB_REPOSITORY || repo
+  }/blob/${process.env.GITHUB_SHA || "HEAD"}`;
 
-      const x = node.url;
-      node.url = matches.length === 2
-        ? node.url.replace(mdRe, "$1") 
-        : node.url.replace(mdRe, "");
-      if (new URL(node.url, "file:///-/").href === "file:///-/README") {
-        node.url = "Home";
-      }
-
-      console.log(`Rewrote ${x} to ${node.url}`);
-    });
-  for (const file of await readdir(d)) {
-    if (!mdRe.test(file)) {
-      continue;
+  await rewriteLinks(d, (url) => {
+    const [path, suffix] = splitPath(url);
+    if (!path) return;
+    const decoded = decodePath(path);
+    if (decoded === undefined) return;
+    // GitHub's repo Markdown view resolves plain relative paths against the
+    // file's directory and /-prefixed paths against the repo root.
+    const target = path.startsWith("/")
+      ? join(workspacePath, decoded)
+      : resolve(sourceDir, decoded);
+    if (contains(sourceDir, target)) {
+      // Links between wiki pages become bare page links (issue #8).
+      if (!pageExtRe.test(decoded)) return;
+      if (target === resolve(sourceDir, "README.md")) return "Home" + suffix;
+      return path.replace(pageExtRe, "") + suffix;
     }
-
-    let md = await readFile(resolve(d, file), "utf-8");
-    md = (await remark().use(plugin).process(md)).toString();
-    await writeFile(resolve(d, file), md);
-  }
+    // Links to other files in the repository become blob view URLs, the same
+    // transformation GitHub applies when rendering in-repo Markdown (#78).
+    if (contains(workspacePath, target) && existsSync(target)) {
+      const parts = relative(workspacePath, target).split(sep);
+      return `${blobBase}/${parts.map(encodeURIComponent).join("/")}${suffix}`;
+    }
+    return;
+  });
 }
 
 await $`git add -Av`;

--- a/cli.ts
+++ b/cli.ts
@@ -110,7 +110,10 @@ if (core.getInput("direction") === "pull") {
   await $`git clone ${wikiGitURL} .`;
 
   if (core.getBooleanInput("preprocess")) {
-    const hasHome = existsSync(resolve(d, "Home.md"));
+    // Only restore Home.md -> README.md when that doesn't clobber a real
+    // README.md page (wikis synced without preprocess can have both).
+    const renameHome = existsSync(resolve(d, "Home.md")) &&
+      !existsSync(resolve(d, "README.md"));
     await rewriteLinks(d, (url) => {
       const [path, suffix] = splitPath(url);
       if (!path || path.startsWith("/") || pageExtRe.test(path)) return;
@@ -118,14 +121,14 @@ if (core.getInput("direction") === "pull") {
       if (decoded === undefined) return;
       const target = resolve(d, decoded);
       if (!contains(d, target)) return;
-      if (hasHome && target === resolve(d, "Home")) {
+      if (renameHome && target === resolve(d, "Home")) {
         return path.replace(/Home$/, "README") + ".md" + suffix;
       }
       if (existsSync(target + ".md")) return path + ".md" + suffix;
       return;
     });
 
-    if (hasHome) {
+    if (renameHome) {
       await rename(resolve(d, "Home.md"), resolve(d, "README.md"));
       console.log("Moved Home.md to README.md");
     }
@@ -195,12 +198,18 @@ await copy(
 
 if (core.getBooleanInput("preprocess")) {
   // https://github.com/nodejs/node/issues/39960
-  if (existsSync(resolve(d, "README.md"))) {
+  // Only promote README.md when the source has no Home.md of its own —
+  // renaming over a real Home.md would silently drop a page.
+  if (
+    existsSync(resolve(d, "README.md")) && !existsSync(resolve(d, "Home.md"))
+  ) {
     await rename(resolve(d, "README.md"), resolve(d, "Home.md"));
     console.log("Moved README.md to Home.md");
   }
 
   const sourceDir = resolve(workspacePath, core.getInput("path"));
+  const readmeIsHome = existsSync(resolve(sourceDir, "README.md")) &&
+    !existsSync(resolve(sourceDir, "Home.md"));
   // Links to source files point at the repo the workflow checked out, which
   // is not necessarily the wiki's repo (cross-repo publishing).
   const blobBase = `${process.env.GITHUB_SERVER_URL || serverURL}/${
@@ -220,7 +229,9 @@ if (core.getBooleanInput("preprocess")) {
     if (contains(sourceDir, target)) {
       // Links between wiki pages become bare page links (issue #8).
       if (!pageExtRe.test(decoded)) return;
-      if (target === resolve(sourceDir, "README.md")) return "Home" + suffix;
+      if (readmeIsHome && target === resolve(sourceDir, "README.md")) {
+        return "Home" + suffix;
+      }
       return path.replace(pageExtRe, "") + suffix;
     }
     // Links to other files in the repository become blob view URLs, the same

--- a/cli.ts
+++ b/cli.ts
@@ -53,9 +53,18 @@ process.env.GH_TOKEN = core.getInput("token");
 process.env.GH_HOST = new URL(core.getInput("github_server_url")).host;
 await $`gh auth setup-git`;
 
-// File extensions GitHub renders as Markdown pages.
+// File extensions GitHub renders as wiki pages, in restore-priority order.
 // https://github.com/github/markup
-const pageExtRe = /\.(?:md|markdown|mdown|mkdn|mkd|mdwn|mkdown|ron)$/;
+// deno-fmt-ignore
+const pageExts = [
+  "md", "markdown", "mdown", "mkdn", "mkd", "mdwn", "mkdown",
+  "asciidoc", "adoc", "asc", "rst", "mediawiki", "wiki",
+  "textile", "rdoc", "org", "creole", "pod",
+];
+const pageExtRe = new RegExp(`\\.(?:${pageExts.join("|")})$`);
+// Only Markdown can be parsed by the remark-based link rewriter; the other
+// page formats are synced verbatim but still count as link targets above.
+const markdownExtRe = /\.(?:md|markdown|mdown|mkdn|mkd|mdwn|mkdown)$/;
 
 // URLs that are plain paths: no scheme (https:, mailto:, ...) and no //host.
 const isPathOnly = (url: string) =>
@@ -93,7 +102,7 @@ async function rewriteLinks(
       node.url = rewritten;
     });
   for (const file of await readdir(dir)) {
-    if (!pageExtRe.test(file)) continue;
+    if (!markdownExtRe.test(file)) continue;
     const path = resolve(dir, file);
     const md = await readFile(path, "utf-8");
     await writeFile(path, (await remark().use(plugin).process(md)).toString());
@@ -124,7 +133,9 @@ if (core.getInput("direction") === "pull") {
       if (renameHome && target === resolve(d, "Home")) {
         return path.replace(/Home$/, "README") + ".md" + suffix;
       }
-      if (existsSync(target + ".md")) return path + ".md" + suffix;
+      for (const ext of pageExts) {
+        if (existsSync(`${target}.${ext}`)) return `${path}.${ext}${suffix}`;
+      }
       return;
     });
 

--- a/cli.ts
+++ b/cli.ts
@@ -20,7 +20,16 @@ import { visit } from "npm:unist-util-visit@^5.0.0";
 import { basename, join, relative, resolve, sep } from "node:path";
 
 core.startGroup("process.env");
-console.table(process.env);
+// The runner masks registered secrets in logs, but don't rely on it —
+// redact anything credential-shaped (covers PATs passed as plain env).
+console.table(
+  Object.fromEntries(
+    Object.entries(process.env).map(([key, value]) => [
+      key,
+      /token|secret|password|credential/i.test(key) ? "***" : value,
+    ]),
+  ),
+);
 core.endGroup();
 
 const isProcessError = (
@@ -39,6 +48,10 @@ const isProcessError = (
 const serverURL = core.getInput("github_server_url");
 const repo = core.getInput("repository");
 const wikiGitURL = `${serverURL}/${repo}.wiki.git`;
+const direction = core.getInput("direction") || "push";
+if (direction !== "push" && direction !== "pull") {
+  throw new DOMException("Unknown direction", "NotSupportedError");
+}
 const workspacePath = process.cwd();
 const d = temporaryDirectory();
 // zx's cd() instead of process.chdir(): zx >=7.2 keeps process.cwd() pinned
@@ -109,7 +122,7 @@ async function rewriteLinks(
   }
 }
 
-if (core.getInput("direction") === "pull") {
+if (direction === "pull") {
   // Sync the wiki back into the source tree: the exact inverse of the push
   // preprocess (issue #67). Clones the wiki, restores source-friendly
   // Markdown (Home.md -> README.md, bare page links -> .md links), and

--- a/cli.ts
+++ b/cli.ts
@@ -17,7 +17,7 @@ import { temporaryDirectory } from "npm:tempy@^3.1.0";
 import { $, cd } from "npm:zx@^7.2.2";
 import { remark } from "npm:remark@^14.0.3";
 import { visit } from "npm:unist-util-visit@^5.0.0";
-import { basename, join, relative, resolve, sep } from "node:path";
+import { basename, dirname, join, relative, resolve, sep } from "node:path";
 
 core.startGroup("process.env");
 // The runner masks registered secrets in logs, but don't rely on it —
@@ -100,25 +100,54 @@ const decodePath = (path: string): string | undefined => {
 const contains = (parent: string, child: string) =>
   child === parent || child.startsWith(parent + sep);
 
-// Rewrites link URLs in every top-level Markdown file in dir. rewrite()
-// returns the new URL, or undefined to leave the link untouched.
+// Every file under dir except the .git folder, sorted shallowest-first.
+async function allFiles(dir: string): Promise<string[]> {
+  const out: string[] = [];
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    if (entry.name === ".git") continue;
+    const path = resolve(dir, entry.name);
+    if (entry.isDirectory()) out.push(...(await allFiles(path)));
+    else out.push(path);
+  }
+  return out.sort((a, b) =>
+    a.split(sep).length - b.split(sep).length || (a < b ? -1 : 1)
+  );
+}
+
+// Rewrites link, image, and reference-definition URLs in every Markdown file
+// under dir. rewrite() gets the URL, the directory of the file it appears
+// in, and whether it renders as an image; it returns the new URL, or
+// undefined to leave it untouched.
 async function rewriteLinks(
   dir: string,
-  rewrite: (url: string) => string | undefined,
+  rewrite: (
+    url: string,
+    fileDir: string,
+    isImage: boolean,
+  ) => string | undefined,
 ) {
-  const plugin = () => (tree: any) =>
-    visit(tree, ["link", "linkReference"], (node: any) => {
-      if (typeof node.url !== "string" || !isPathOnly(node.url)) return;
-      const rewritten = rewrite(node.url);
-      if (rewritten == null || rewritten === node.url) return;
-      console.log(`Rewrote ${node.url} to ${rewritten}`);
-      node.url = rewritten;
-    });
-  for (const file of await readdir(dir)) {
-    if (!markdownExtRe.test(file)) continue;
-    const path = resolve(dir, file);
-    const md = await readFile(path, "utf-8");
-    await writeFile(path, (await remark().use(plugin).process(md)).toString());
+  for (const file of await allFiles(dir)) {
+    if (!markdownExtRe.test(basename(file))) continue;
+    const fileDir = dirname(file);
+    const plugin = () => (tree: any) => {
+      // A definition backs both link and image references; classify each by
+      // how it's actually referenced.
+      const imageDefs = new Set<string>();
+      visit(tree, "imageReference", (node: any) => {
+        imageDefs.add(node.identifier);
+      });
+      visit(tree, ["link", "image", "definition"], (node: any) => {
+        if (typeof node.url !== "string" || !isPathOnly(node.url)) return;
+        const isImage = node.type === "image" ||
+          (node.type === "definition" && imageDefs.has(node.identifier));
+        const rewritten = rewrite(node.url, fileDir, isImage);
+        if (rewritten == null || rewritten === node.url) return;
+        console.log(`Rewrote ${node.url} to ${rewritten}`);
+        node.url = rewritten;
+      });
+    };
+    const md = await readFile(file, "utf-8");
+    await writeFile(file, (await remark().use(plugin).process(md)).toString());
   }
 }
 
@@ -136,19 +165,42 @@ if (direction === "pull") {
     // README.md page (wikis synced without preprocess can have both).
     const renameHome = existsSync(resolve(d, "Home.md")) &&
       !existsSync(resolve(d, "README.md"));
-    await rewriteLinks(d, (url) => {
+    // The wiki serves pages flat by basename, so a link's textual path may
+    // not point at the page's real location. Index page name -> file
+    // (shallowest file wins a name collision).
+    const pageIndex = new Map<string, string>();
+    for (const file of await allFiles(d)) {
+      const name = basename(file);
+      if (!pageExtRe.test(name)) continue;
+      const page = name.replace(pageExtRe, "");
+      if (!pageIndex.has(page)) pageIndex.set(page, file);
+    }
+    const relativeTo = (fileDir: string, file: string) =>
+      relative(fileDir, file).split(sep).join("/");
+
+    await rewriteLinks(d, (url, fileDir, isImage) => {
+      if (isImage) return;
       const [path, suffix] = splitPath(url);
       if (!path || path.startsWith("/") || pageExtRe.test(path)) return;
       const decoded = decodePath(path);
       if (decoded === undefined) return;
-      const target = resolve(d, decoded);
+      const target = resolve(fileDir, decoded);
       if (!contains(d, target)) return;
-      if (renameHome && target === resolve(d, "Home")) {
-        return path.replace(/Home$/, "README") + ".md" + suffix;
+      if (renameHome && basename(decoded) === "Home") {
+        // Home.md is about to become README.md.
+        if (target === resolve(d, "Home")) {
+          return path.replace(/Home$/, "README") + ".md" + suffix;
+        }
+        return relativeTo(fileDir, resolve(d, "README.md")) + suffix;
       }
+      // The textual path already points at the page's directory...
       for (const ext of pageExts) {
         if (existsSync(`${target}.${ext}`)) return `${path}.${ext}${suffix}`;
       }
+      // ...otherwise it's a flat wiki-namespace link: point at the page's
+      // actual file.
+      const file = pageIndex.get(basename(decoded));
+      if (file !== undefined) return relativeTo(fileDir, file) + suffix;
       return;
     });
 
@@ -235,34 +287,48 @@ if (core.getBooleanInput("preprocess")) {
   const readmeIsHome = existsSync(resolve(sourceDir, "README.md")) &&
     !existsSync(resolve(sourceDir, "Home.md"));
   // Links to source files point at the repo the workflow checked out, which
-  // is not necessarily the wiki's repo (cross-repo publishing).
-  const blobBase = `${process.env.GITHUB_SERVER_URL || serverURL}/${
+  // is not necessarily the wiki's repo (cross-repo publishing). Images need
+  // the raw file (a blob page doesn't render inside <img>); the /raw/ route
+  // works on github.com and GitHub Enterprise alike.
+  const sourceRepoBase = `${process.env.GITHUB_SERVER_URL || serverURL}/${
     process.env.GITHUB_REPOSITORY || repo
-  }/blob/${process.env.GITHUB_SHA || "HEAD"}`;
+  }`;
+  const sourceRef = process.env.GITHUB_SHA || "HEAD";
 
-  await rewriteLinks(d, (url) => {
+  await rewriteLinks(d, (url, fileDir, isImage) => {
     const [path, suffix] = splitPath(url);
     if (!path) return;
     const decoded = decodePath(path);
     if (decoded === undefined) return;
-    // GitHub's repo Markdown view resolves plain relative paths against the
-    // file's directory and /-prefixed paths against the repo root.
+    // fileDir is inside the wiki copy; resolve links against the matching
+    // directory of the source tree, the way GitHub's repo Markdown view
+    // resolves them (/-prefixed paths resolve against the repo root).
+    const sourceFileDir = resolve(sourceDir, relative(d, fileDir));
     const target = path.startsWith("/")
       ? join(workspacePath, decoded)
-      : resolve(sourceDir, decoded);
+      : resolve(sourceFileDir, decoded);
     if (contains(sourceDir, target)) {
-      // Links between wiki pages become bare page links (issue #8).
-      if (!pageExtRe.test(decoded)) return;
+      // Images and other assets ship with the wiki; only page links need to
+      // become bare page links (issue #8).
+      if (isImage || !pageExtRe.test(decoded)) return;
       if (readmeIsHome && target === resolve(sourceDir, "README.md")) {
         return "Home" + suffix;
       }
-      return path.replace(pageExtRe, "") + suffix;
+      // The wiki serves pages flat by basename. A same-directory link keeps
+      // its textual form; anything else must link by page name.
+      if (dirname(target) === sourceFileDir) {
+        return path.replace(pageExtRe, "") + suffix;
+      }
+      return basename(target).replace(pageExtRe, "") + suffix;
     }
-    // Links to other files in the repository become blob view URLs, the same
-    // transformation GitHub applies when rendering in-repo Markdown (#78).
+    // Links to other files in the repository become blob view URLs (or raw
+    // URLs for images), the same transformation GitHub applies when
+    // rendering in-repo Markdown (#78).
     if (contains(workspacePath, target) && existsSync(target)) {
       const parts = relative(workspacePath, target).split(sep);
-      return `${blobBase}/${parts.map(encodeURIComponent).join("/")}${suffix}`;
+      return `${sourceRepoBase}/${isImage ? "raw" : "blob"}/${sourceRef}/${
+        parts.map(encodeURIComponent).join("/")
+      }${suffix}`;
     }
     return;
   });

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -42,10 +42,20 @@ interface Scenario {
   remote: Record<string, string> | "empty";
   /** Contents of the workspace's wiki/ source directory. */
   workspaceWiki: Record<string, string>;
+  /** Extra workspace files outside the wiki/ source directory. */
+  workspaceFiles?: Record<string, string>;
   /** Exact expected wiki repo contents after the action runs. */
   expect: Record<string, string>;
   preprocess?: boolean;
 }
+
+// Fixed "checked out repo" identity so blob URLs in expectations are static.
+const SOURCE_ENV = {
+  GITHUB_SERVER_URL: "https://github.test",
+  GITHUB_REPOSITORY: "octo/source",
+  GITHUB_SHA: "cafebabe",
+};
+const BLOB_BASE = `${SOURCE_ENV.GITHUB_SERVER_URL}/${SOURCE_ENV.GITHUB_REPOSITORY}/blob/${SOURCE_ENV.GITHUB_SHA}`;
 
 async function runScenario(scenario: Scenario): Promise<void> {
   const root = await Deno.makeTempDir({ prefix: "wiki-action-test-" });
@@ -77,6 +87,7 @@ async function runScenario(scenario: Scenario): Promise<void> {
     const workspace = join(root, "workspace");
     await Deno.mkdir(join(workspace, "wiki"), { recursive: true });
     await writeFiles(join(workspace, "wiki"), scenario.workspaceWiki);
+    await writeFiles(workspace, scenario.workspaceFiles ?? {});
     await git(workspace, "init", "-q", "-b", "main");
     await git(workspace, "add", "-A");
     await git(
@@ -108,6 +119,7 @@ async function runScenario(scenario: Scenario): Promise<void> {
     env.HOME = home;
     env.USERPROFILE = home;
     env.XDG_CONFIG_HOME = join(home, ".config");
+    Object.assign(env, SOURCE_ENV);
     env.INPUT_STRATEGY = scenario.strategy ?? "clone";
     env.INPUT_REPOSITORY = REPO;
     env.INPUT_GITHUB_SERVER_URL = pathToFileURL(join(root, "remote")).href;
@@ -156,7 +168,14 @@ async function runScenario(scenario: Scenario): Promise<void> {
     const workspaceEntries = [...Deno.readDirSync(workspace)]
       .map((e) => e.name)
       .sort();
-    assertEquals(workspaceEntries, [".git", "wiki"]);
+    const expectedEntries = [
+      ...new Set([
+        ".git",
+        "wiki",
+        ...Object.keys(scenario.workspaceFiles ?? {}).map((f) => f.split("/")[0]),
+      ]),
+    ].sort();
+    assertEquals(workspaceEntries, expectedEntries);
   } finally {
     await Deno.remove(root, { recursive: true }).catch(() => {});
   }
@@ -289,5 +308,231 @@ Deno.test("preprocess renames README.md to Home.md and rewrites .md links", () =
     expect: {
       "Home.md": "# Title\n\n[Usage](Usage)",
       "Usage.md": "usage",
+    },
+  }));
+
+// Issue #78: relative links that point at real files in the checked-out
+// repository (outside the wiki source dir) become blob view URLs, mirroring
+// how GitHub renders in-repo Markdown. Everything else is left alone.
+Deno.test("preprocess rewrites repo file links to blob URLs (#78)", () =>
+  runScenario({
+    preprocess: true,
+    remote: { "Home.md": "old" },
+    workspaceFiles: {
+      "scripts/update.sh": "#!/bin/sh",
+      "CONTRIBUTING.md": "how to contribute",
+      "docs & files/read me.txt": "spaces",
+    },
+    workspaceWiki: {
+      "README.md": [
+        "[script](../scripts/update.sh)",
+        "[script with anchor](../scripts/update.sh#L1)",
+        "[root relative](/scripts/update.sh)",
+        "[repo markdown](../CONTRIBUTING.md)",
+        "[encoded](../docs%20&%20files/read%20me.txt)",
+        "[missing](../scripts/nope.sh)",
+        "[external](https://example.com/script.sh)",
+        "[page](./Usage.md#anchor)",
+        "[asset](./diagram.png)",
+      ].join("\n\n") + "\n",
+      "Usage.md": "usage",
+      "diagram.png": "not really a png",
+    },
+    expect: {
+      "Home.md": [
+        `[script](${BLOB_BASE}/scripts/update.sh)`,
+        `[script with anchor](${BLOB_BASE}/scripts/update.sh#L1)`,
+        `[root relative](${BLOB_BASE}/scripts/update.sh)`,
+        `[repo markdown](${BLOB_BASE}/CONTRIBUTING.md)`,
+        `[encoded](${BLOB_BASE}/docs%20%26%20files/read%20me.txt)`,
+        "[missing](../scripts/nope.sh)",
+        "[external](https://example.com/script.sh)",
+        "[page](./Usage#anchor)",
+        "[asset](./diagram.png)",
+      ].join("\n\n"),
+      "Usage.md": "usage",
+      "diagram.png": "not really a png",
+    },
+  }));
+
+// ---------------------------------------------------------------------------
+// direction: pull (issue #67) — wiki -> workspace sync with the inverse
+// preprocess transforms.
+// ---------------------------------------------------------------------------
+
+interface PullScenario {
+  /** Pre-existing wiki contents. */
+  remote: Record<string, string>;
+  /** Pre-existing contents of the workspace's wiki/ directory. */
+  workspaceWiki: Record<string, string>;
+  /** Exact expected workspace wiki/ contents after the action runs. */
+  expect: Record<string, string>;
+  preprocess?: boolean;
+  dryRun?: boolean;
+}
+
+async function runPullScenario(scenario: PullScenario): Promise<void> {
+  const root = await Deno.makeTempDir({ prefix: "wiki-action-test-" });
+  try {
+    const bare = join(root, "remote", ...`${REPO}.wiki.git`.split("/"));
+    await Deno.mkdir(bare, { recursive: true });
+    await git(bare, "init", "--bare", "-q");
+    await git(bare, "symbolic-ref", "HEAD", "refs/heads/master");
+    const seed = join(root, "seed");
+    await Deno.mkdir(seed);
+    await git(seed, "init", "-q", "-b", "master");
+    await writeFiles(seed, scenario.remote);
+    await git(seed, "add", "-A");
+    await git(
+      seed,
+      "-c", "user.email=seed@example.com",
+      "-c", "user.name=seed",
+      "commit", "-qm", "existing wiki content",
+    );
+    await git(seed, "push", "-q", bare, "master");
+
+    const workspace = join(root, "workspace");
+    await Deno.mkdir(join(workspace, "wiki"), { recursive: true });
+    await writeFiles(join(workspace, "wiki"), scenario.workspaceWiki);
+    await git(workspace, "init", "-q", "-b", "main");
+    await git(workspace, "add", "-A");
+    await git(
+      workspace,
+      "-c", "user.email=ws@example.com",
+      "-c", "user.name=ws",
+      "commit", "-qm", "workspace", "--allow-empty",
+    );
+
+    const bin = join(root, "bin");
+    await Deno.mkdir(bin);
+    await Deno.writeTextFile(join(bin, "gh"), "#!/bin/sh\nexit 0\n");
+    if (Deno.build.os === "windows") {
+      await Deno.writeTextFile(join(bin, "gh.cmd"), "@echo off\r\nexit /b 0\r\n");
+    } else {
+      await Deno.chmod(join(bin, "gh"), 0o755);
+    }
+
+    const home = join(root, "home");
+    await Deno.mkdir(home);
+
+    const env: Record<string, string> = { ...Deno.env.toObject() };
+    for (const key of Object.keys(env)) {
+      if (key.toUpperCase() === "PATH") delete env[key];
+    }
+    env.PATH = bin + delimiter + (Deno.env.get("PATH") ?? "");
+    env.HOME = home;
+    env.USERPROFILE = home;
+    env.XDG_CONFIG_HOME = join(home, ".config");
+    env.INPUT_DIRECTION = "pull";
+    env.INPUT_STRATEGY = "clone";
+    env.INPUT_REPOSITORY = REPO;
+    env.INPUT_GITHUB_SERVER_URL = pathToFileURL(join(root, "remote")).href;
+    env.INPUT_TOKEN = "test-token";
+    env.INPUT_PATH = "wiki";
+    env.INPUT_COMMIT_MESSAGE = "test commit";
+    env.INPUT_IGNORE = "";
+    env.INPUT_DRY_RUN = String(scenario.dryRun ?? false);
+    env.INPUT_PREPROCESS = String(scenario.preprocess ?? true);
+    env.INPUT_DISABLE_EMPTY_COMMITS = "false";
+
+    const out = await new Deno.Command(Deno.execPath(), {
+      args: ["run", "-A", CLI_PATH],
+      cwd: workspace,
+      env,
+      clearEnv: true,
+      stdout: "piped",
+      stderr: "piped",
+    }).output();
+    if (!out.success) {
+      throw new Error(
+        "cli.ts failed\n--- stdout ---\n" +
+          new TextDecoder().decode(out.stdout) +
+          "\n--- stderr ---\n" +
+          new TextDecoder().decode(out.stderr),
+      );
+    }
+
+    // The workspace wiki/ dir must now contain exactly the expected files.
+    const files: string[] = [];
+    const walk = (dir: string, prefix: string) => {
+      for (const entry of Deno.readDirSync(dir)) {
+        if (entry.name === ".git") continue;
+        if (entry.isDirectory) walk(join(dir, entry.name), `${prefix}${entry.name}/`);
+        else files.push(`${prefix}${entry.name}`);
+      }
+    };
+    walk(join(workspace, "wiki"), "");
+    assertEquals(files.sort(), Object.keys(scenario.expect).sort());
+    for (const [path, content] of Object.entries(scenario.expect)) {
+      assertEquals(
+        (await Deno.readTextFile(join(workspace, "wiki", ...path.split("/")))).trim(),
+        content.trim(),
+        `content mismatch for ${path}`,
+      );
+    }
+
+    // Pull mode must never push anything to the wiki remote.
+    assertEquals(
+      await git(bare, "log", "--format=%s", "master"),
+      "existing wiki content",
+    );
+  } finally {
+    await Deno.remove(root, { recursive: true }).catch(() => {});
+  }
+}
+
+Deno.test("pull: mirrors the wiki into the workspace with inverse preprocess (#67)", () =>
+  runPullScenario({
+    remote: {
+      "Home.md": [
+        "[another page](./another-page)",
+        "[with anchor](./another-page#section)",
+        "[home](./Home)",
+        "[external](https://example.com/page)",
+        "[missing](./no-such-page)",
+      ].join("\n\n") + "\n",
+      "another-page.md": "another page\n",
+    },
+    workspaceWiki: {
+      "README.md": "stale readme\n",
+      "Stale-Page.md": "deleted from the wiki\n",
+    },
+    expect: {
+      "README.md": [
+        "[another page](./another-page.md)",
+        "[with anchor](./another-page.md#section)",
+        "[home](./README.md)",
+        "[external](https://example.com/page)",
+        "[missing](./no-such-page)",
+      ].join("\n\n"),
+      "another-page.md": "another page",
+    },
+  }));
+
+Deno.test("pull: preprocess=false copies the wiki verbatim", () =>
+  runPullScenario({
+    preprocess: false,
+    remote: {
+      "Home.md": "[another page](./another-page)\n",
+      "another-page.md": "another page\n",
+    },
+    workspaceWiki: {},
+    expect: {
+      "Home.md": "[another page](./another-page)",
+      "another-page.md": "another page",
+    },
+  }));
+
+Deno.test("pull: dry run leaves the workspace untouched", () =>
+  runPullScenario({
+    dryRun: true,
+    remote: {
+      "Home.md": "new wiki home\n",
+    },
+    workspaceWiki: {
+      "README.md": "original readme\n",
+    },
+    expect: {
+      "README.md": "original readme",
     },
   }));

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -311,6 +311,24 @@ Deno.test("preprocess renames README.md to Home.md and rewrites .md links", () =
     },
   }));
 
+// A source tree can legitimately contain both README.md and Home.md as
+// separate pages (e.g. wikis previously synced without preprocess, like
+// opensearch-project/opensearch-build). Promoting README.md must never
+// clobber a real Home.md, and links must keep pointing at the right pages.
+Deno.test("preprocess keeps a real Home.md instead of clobbering it with README.md", () =>
+  runScenario({
+    preprocess: true,
+    remote: { "Home.md": "old" },
+    workspaceWiki: {
+      "README.md": "readme page\n\n[home](Home.md)\n",
+      "Home.md": "real home\n\n[readme](README.md)\n",
+    },
+    expect: {
+      "README.md": "readme page\n\n[home](Home)",
+      "Home.md": "real home\n\n[readme](README)",
+    },
+  }));
+
 // Issue #78: relative links that point at real files in the checked-out
 // repository (outside the wiki source dir) become blob view URLs, mirroring
 // how GitHub renders in-repo Markdown. Everything else is left alone.
@@ -506,6 +524,19 @@ Deno.test("pull: mirrors the wiki into the workspace with inverse preprocess (#6
         "[missing](./no-such-page)",
       ].join("\n\n"),
       "another-page.md": "another page",
+    },
+  }));
+
+Deno.test("pull: keeps a real README.md instead of clobbering it with Home.md", () =>
+  runPullScenario({
+    remote: {
+      "Home.md": "wiki home\n\n[readme](./README)\n",
+      "README.md": "wiki readme\n",
+    },
+    workspaceWiki: {},
+    expect: {
+      "Home.md": "wiki home\n\n[readme](./README.md)",
+      "README.md": "wiki readme",
     },
   }));
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -512,8 +512,13 @@ async function runPullScenario(scenario: PullScenario): Promise<void> {
     walk(join(workspace, "wiki"), "");
     assertEquals(files.sort(), Object.keys(scenario.expect).sort());
     for (const [path, content] of Object.entries(scenario.expect)) {
+      // Windows runners clone with core.autocrlf=true, so files the cli
+      // copies verbatim (non-Markdown pages) carry CRLF line endings.
+      const actual = await Deno.readTextFile(
+        join(workspace, "wiki", ...path.split("/")),
+      );
       assertEquals(
-        (await Deno.readTextFile(join(workspace, "wiki", ...path.split("/")))).trim(),
+        actual.replaceAll("\r\n", "\n").trim(),
         content.trim(),
         `content mismatch for ${path}`,
       );

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -373,6 +373,36 @@ Deno.test("preprocess rewrites repo file links to blob URLs (#78)", () =>
     },
   }));
 
+// GitHub wikis render more than Markdown (AsciiDoc, reStructuredText, ...).
+// Links from Markdown pages to pages in any supported format must be
+// bare-linked, while the non-Markdown files themselves are synced verbatim —
+// they must never be fed through the Markdown parser.
+Deno.test("preprocess bare-links pages of any GitHub-supported format", () =>
+  runScenario({
+    preprocess: true,
+    remote: { "Home.md": "old" },
+    workspaceWiki: {
+      "Home.md": [
+        "[guide](./Guide.rst)",
+        "[notes](Notes.adoc#setup)",
+        "[usage](Usage.md)",
+      ].join("\n\n") + "\n",
+      "Guide.rst": "Title\n=====\n\n`a link <./Home>`_ and *rst stuff*\n",
+      "Notes.adoc": "= Notes\n\nSome asciidoc.\n",
+      "Usage.md": "usage",
+    },
+    expect: {
+      "Home.md": [
+        "[guide](./Guide)",
+        "[notes](Notes#setup)",
+        "[usage](Usage)",
+      ].join("\n\n"),
+      "Guide.rst": "Title\n=====\n\n`a link <./Home>`_ and *rst stuff*",
+      "Notes.adoc": "= Notes\n\nSome asciidoc.",
+      "Usage.md": "usage",
+    },
+  }));
+
 // ---------------------------------------------------------------------------
 // direction: pull (issue #67) — wiki -> workspace sync with the inverse
 // preprocess transforms.
@@ -524,6 +554,21 @@ Deno.test("pull: mirrors the wiki into the workspace with inverse preprocess (#6
         "[missing](./no-such-page)",
       ].join("\n\n"),
       "another-page.md": "another page",
+    },
+  }));
+
+Deno.test("pull: restores the extension pages actually have, not just .md", () =>
+  runPullScenario({
+    remote: {
+      "Home.md": "[guide](./Guide)\n\n[usage](./Usage#intro)\n",
+      "Guide.rst": "Title\n=====\n\n*rst stuff*\n",
+      "Usage.md": "usage",
+    },
+    workspaceWiki: {},
+    expect: {
+      "README.md": "[guide](./Guide.rst)\n\n[usage](./Usage.md#intro)",
+      "Guide.rst": "Title\n=====\n\n*rst stuff*",
+      "Usage.md": "usage",
     },
   }));
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -56,6 +56,7 @@ const SOURCE_ENV = {
   GITHUB_SHA: "cafebabe",
 };
 const BLOB_BASE = `${SOURCE_ENV.GITHUB_SERVER_URL}/${SOURCE_ENV.GITHUB_REPOSITORY}/blob/${SOURCE_ENV.GITHUB_SHA}`;
+const RAW_BASE = `${SOURCE_ENV.GITHUB_SERVER_URL}/${SOURCE_ENV.GITHUB_REPOSITORY}/raw/${SOURCE_ENV.GITHUB_SHA}`;
 
 async function runScenario(scenario: Scenario): Promise<void> {
   const root = await Deno.makeTempDir({ prefix: "wiki-action-test-" });
@@ -373,6 +374,56 @@ Deno.test("preprocess rewrites repo file links to blob URLs (#78)", () =>
     },
   }));
 
+// Pages in subdirectories are preprocessed too. The wiki serves pages flat
+// by basename, so cross-directory page links become bare page names while
+// same-directory links keep their textual form. Images pointing at repo
+// files become raw URLs (a blob page doesn't render inside <img>), images
+// shipping with the wiki stay relative, and reference-style definitions are
+// rewritten according to how they're referenced.
+Deno.test("preprocess rewrites subdirectory pages, images, and definitions", () =>
+  runScenario({
+    preprocess: true,
+    remote: { "Home.md": "old" },
+    workspaceFiles: {
+      "assets/logo.png": "png bytes",
+      "scripts/run.sh": "#!/bin/sh",
+    },
+    workspaceWiki: {
+      "Home.md": [
+        "![repo image](../assets/logo.png)",
+        "![wiki image](img/local.png)",
+        "[ref link][1]",
+        "![ref image][2]",
+        "[1]: ../scripts/run.sh",
+        "[2]: ../assets/logo.png",
+      ].join("\n\n") + "\n",
+      "img/local.png": "png",
+      "docs/Guide.md": [
+        "[same dir](./Extra.md)",
+        "[root page](../Home.md#top)",
+        "[script](../../scripts/run.sh)",
+      ].join("\n\n") + "\n",
+      "docs/Extra.md": "extra",
+    },
+    expect: {
+      "Home.md": [
+        `![repo image](${RAW_BASE}/assets/logo.png)`,
+        "![wiki image](img/local.png)",
+        "[ref link][1]",
+        "![ref image][2]",
+        `[1]: ${BLOB_BASE}/scripts/run.sh`,
+        `[2]: ${RAW_BASE}/assets/logo.png`,
+      ].join("\n\n"),
+      "img/local.png": "png",
+      "docs/Guide.md": [
+        "[same dir](./Extra)",
+        "[root page](Home#top)",
+        `[script](${BLOB_BASE}/scripts/run.sh)`,
+      ].join("\n\n"),
+      "docs/Extra.md": "extra",
+    },
+  }));
+
 // GitHub wikis render more than Markdown (AsciiDoc, reStructuredText, ...).
 // Links from Markdown pages to pages in any supported format must be
 // bare-linked, while the non-Markdown files themselves are synced verbatim —
@@ -574,6 +625,24 @@ Deno.test("pull: restores the extension pages actually have, not just .md", () =
       "README.md": "[guide](./Guide.rst)\n\n[usage](./Usage.md#intro)",
       "Guide.rst": "Title\n=====\n\n*rst stuff*",
       "Usage.md": "usage",
+    },
+  }));
+
+// The wiki serves pages flat by basename, so a wiki-authored link may not
+// point at the page's real location on disk. The pull restores the actual
+// file path relative to the linking page.
+Deno.test("pull: restores file paths for flat wiki links from subdirectory pages", () =>
+  runPullScenario({
+    remote: {
+      "Home.md": "[guide](guide-page)\n",
+      "docs/guide-page.md": "[back home](Home)\n\n[sibling](./other)\n",
+      "docs/other.md": "other\n",
+    },
+    workspaceWiki: {},
+    expect: {
+      "README.md": "[guide](docs/guide-page.md)",
+      "docs/guide-page.md": "[back home](../README.md)\n\n[sibling](./other.md)",
+      "docs/other.md": "other",
     },
   }));
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -604,6 +604,24 @@ Deno.test("pull: preprocess=false copies the wiki verbatim", () =>
     },
   }));
 
+Deno.test("rejects an unknown direction instead of silently pushing", async () => {
+  // The direction check runs before any other input is read, so the
+  // inherited environment doesn't matter here.
+  const out = await new Deno.Command(Deno.execPath(), {
+    args: ["run", "-A", CLI_PATH],
+    env: { INPUT_DIRECTION: "sideways" },
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+  if (out.success) {
+    throw new Error("cli.ts accepted direction=sideways");
+  }
+  assertEquals(
+    new TextDecoder().decode(out.stderr).includes("Unknown direction"),
+    true,
+  );
+});
+
 Deno.test("pull: dry run leaves the workspace untouched", () =>
   runPullScenario({
     dryRun: true,

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -1,16 +1,21 @@
 // Live end-to-end tests for cli.ts against the repository's real wiki.
 //
 // The push test publishes wiki/ to the actual GitHub wiki, clones it back to
-// verify the pushed contents, and then verifies the *published* result over
-// HTTP: the pages GitHub renders, that every link on the Home page resolves,
-// and that the in-wiki anchor link targets a heading that exists. The pull
-// test then syncs the live wiki back into a scratch workspace and verifies
-// the inverse preprocess transforms.
+// verify the pushed contents, and then verifies the *published* result the
+// way a wiki reader would: it fetches the rendered Home page HTML, extracts
+// the links GitHub actually rendered, navigates every one of them, and
+// asserts both that they load (no 404s) and that the destination shows the
+// expected content (the anchor's target heading, the real file at the pinned
+// commit). The pull test then syncs the live wiki back into a scratch
+// workspace and verifies the inverse preprocess transforms.
 //
 // These tests write to the real wiki, so they only run when a token is
 // available AND we're either in GitHub Actions or explicitly opted in:
 //
 //   E2E=1 GITHUB_TOKEN=$(gh auth token) deno test -A tests/e2e.test.ts
+//
+// Outside CI the current commit is used for blob links, so HEAD must be
+// pushed for the navigation checks to pass.
 import {
   assert,
   assertEquals,
@@ -25,10 +30,32 @@ const CLI_PATH = join(ROOT, "cli.ts");
 
 const REPO = Deno.env.get("GITHUB_REPOSITORY") ??
   "Andrew-Chen-Wang/github-wiki-action";
-// cli.ts pins blob links to GITHUB_SHA and falls back to HEAD outside CI.
-const SHA = Deno.env.get("GITHUB_SHA") ?? "HEAD";
+const SHA = Deno.env.get("GITHUB_SHA") ?? gitSync(ROOT, "rev-parse", "HEAD");
 const BLOB_BASE = `https://github.com/${REPO}/blob/${SHA}`;
 const WIKI_BASE = `https://github.com/${REPO}/wiki`;
+
+// Distinctive text expected inside each repository file the wiki links to.
+const FILE_MARKERS: Record<string, string> = {
+  "cli.ts": "gh auth setup-git",
+  "tests/cli.test.ts": "Integration tests for cli.ts",
+};
+const ANCHOR = "some＿impꗝrtant＿stuff-";
+const PAGE_MARKER = "we gotta give this a try";
+
+function gitSync(cwd: string, ...args: string[]): string {
+  const out = new Deno.Command("git", {
+    args,
+    cwd,
+    stdout: "piped",
+    stderr: "piped",
+  }).outputSync();
+  if (!out.success) {
+    throw new Error(
+      `git ${args.join(" ")} failed:\n${new TextDecoder().decode(out.stderr)}`,
+    );
+  }
+  return new TextDecoder().decode(out.stdout).trim();
+}
 
 function ghToken(): string {
   const env = Deno.env.get("GITHUB_TOKEN") ?? Deno.env.get("GH_TOKEN");
@@ -67,7 +94,8 @@ async function git(cwd: string, ...args: string[]): Promise<string> {
 
 // Runs cli.ts against the real wiki. HOME is sandboxed so the cli's global
 // git config writes don't leak into the host; everything else (PATH with the
-// real gh, GITHUB_* vars) is inherited.
+// real gh) is inherited. GITHUB_* vars are pinned so the cli and this test
+// agree on the source repo and commit.
 async function runCli(cwd: string, inputs: Record<string, string>) {
   const home = await Deno.makeTempDir({ prefix: "wiki-e2e-home-" });
   const out = await new Deno.Command(Deno.execPath(), {
@@ -77,6 +105,9 @@ async function runCli(cwd: string, inputs: Record<string, string>) {
       HOME: home,
       USERPROFILE: home,
       XDG_CONFIG_HOME: join(home, ".config"),
+      GITHUB_SERVER_URL: "https://github.com",
+      GITHUB_REPOSITORY: REPO,
+      GITHUB_SHA: SHA,
       INPUT_STRATEGY: "clone",
       INPUT_REPOSITORY: REPO,
       INPUT_GITHUB_SERVER_URL: "https://github.com",
@@ -117,13 +148,14 @@ async function fetchOk(url: string): Promise<string> {
 }
 
 Deno.test({
-  name: "e2e push: publishes the wiki and every Home page link resolves",
+  name: "e2e push: publishes the wiki and the rendered Home page links work",
   ignore: !ENABLED,
   fn: async () => {
     await runCli(ROOT, {});
 
-    // Clone the wiki back: the pushed tree must mirror the wiki/ source
-    // directory with README.md renamed to Home.md.
+    // --- The wiki repo: the pushed tree must mirror the wiki/ source
+    // directory with README.md renamed to Home.md, and the preprocess must
+    // have rewritten the links (#8, #78).
     const clone = await Deno.makeTempDir({ prefix: "wiki-e2e-clone-" });
     await git(
       clone,
@@ -141,38 +173,69 @@ Deno.test({
       .sort();
     assertEquals(wikiFiles, sourceFiles);
 
-    // Preprocess transforms: page links went bare (#8) and repo-file links
-    // became blob URLs pinned to this commit (#78).
     const home = await Deno.readTextFile(join(clone, "Home.md"));
     assertStringIncludes(home, "(./another-page)");
     assert(!home.includes("(./another-page.md)"), "page link kept .md");
     assertStringIncludes(home, `${BLOB_BASE}/cli.ts`);
     assertStringIncludes(home, `${BLOB_BASE}/tests/cli.test.ts`);
 
-    // Navigate every link on the published Home page: in-wiki links resolve
-    // relative to the wiki, blob links are absolute. All must load.
-    const links = [...home.matchAll(/\]\(([^)]+)\)/g)].map((m) => m[1]);
-    assert(links.length >= 4, `only found ${links.length} links on Home`);
-    for (const link of links) {
-      const path = link.split("#")[0];
-      if (!path) continue; // same-page anchor
-      assert(
-        path.startsWith("./") || path.startsWith("https://"),
-        `unexpected link on Home: ${link}`,
-      );
-      const target = path.startsWith("./")
-        ? `${WIKI_BASE}/${path.slice(2)}`
-        : path;
-      await fetchOk(target);
-    }
+    // --- The rendered Home page: extract the links GitHub actually rendered
+    // in the page HTML. Gollum emits in-wiki page links as "wiki/./<page>"
+    // and leaves the blob URLs absolute.
+    const homeHtml = await fetchOk(WIKI_BASE);
+    const hrefs = [...homeHtml.matchAll(/href="([^"]+)"/g)].map((m) => m[1]);
+    const pageLinks = [
+      ...new Set(hrefs.filter((h) => h.startsWith("wiki/"))),
+    ].map((h) => new URL(h, WIKI_BASE)); // resolve like a browser would
+    const blobLinks = [
+      ...new Set(
+        hrefs.filter((h) => h.startsWith(`https://github.com/${REPO}/blob/`)),
+      ),
+    ];
 
-    // The rendered Home page shows the blob link, and the in-wiki anchor
-    // link targets a heading that exists on the rendered destination page.
-    assertStringIncludes(await fetchOk(WIKI_BASE), `${BLOB_BASE}/cli.ts`);
-    assertStringIncludes(
-      await fetchOk(`${WIKI_BASE}/another-page`),
-      "some＿impꗝrtant＿stuff-",
+    // The repo-file links must be rendered pinned to this exact commit.
+    assertEquals(blobLinks.sort(), [
+      `${BLOB_BASE}/cli.ts`,
+      `${BLOB_BASE}/tests/cli.test.ts`,
+    ]);
+    // The in-wiki links must lead to the other page, one with the anchor.
+    assert(
+      pageLinks.some((u) => u.href === `${WIKI_BASE}/another-page`),
+      `no rendered link to another-page in ${pageLinks.map((u) => u.href)}`,
     );
+    assert(
+      pageLinks.some(
+        (u) =>
+          u.href ===
+            `${WIKI_BASE}/another-page#${encodeURIComponent(ANCHOR)}`,
+      ),
+      "no rendered link carrying the section anchor",
+    );
+
+    // --- Navigate every rendered link and verify the destination content.
+    for (const page of new Set(pageLinks.map((u) => u.origin + u.pathname))) {
+      const html = await fetchOk(page);
+      // The linked page really is another-page...
+      assertStringIncludes(html, PAGE_MARKER);
+      // ...and the heading the anchor link points at exists on it.
+      assertStringIncludes(html, ANCHOR);
+    }
+    for (const blob of blobLinks) {
+      const path = blob.slice(`${BLOB_BASE}/`.length);
+      // The blob view loads and shows this file at this commit...
+      assertStringIncludes(
+        await fetchOk(blob),
+        `<title>${REPO.split("/")[1]}/${path} at ${SHA}`,
+      );
+      // ...and the file content at that exact ref is the real file.
+      assertStringIncludes(
+        await fetchOk(
+          `https://raw.githubusercontent.com/${REPO}/${SHA}/${path}`,
+        ),
+        FILE_MARKERS[path] ?? "",
+        `unexpected content for ${path}`,
+      );
+    }
   },
 });
 
@@ -205,10 +268,7 @@ Deno.test({
     );
     assert(existsSync(join(workspace, "wiki", "another-page.md")));
     assertStringIncludes(readme, "(./another-page.md)");
-    assertStringIncludes(
-      readme,
-      "(./another-page.md#some＿impꗝrtant＿stuff-)",
-    );
+    assertStringIncludes(readme, `(./another-page.md#${ANCHOR})`);
     assertStringIncludes(readme, `${BLOB_BASE}/cli.ts`);
   },
 });

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -1,0 +1,214 @@
+// Live end-to-end tests for cli.ts against the repository's real wiki.
+//
+// The push test publishes wiki/ to the actual GitHub wiki, clones it back to
+// verify the pushed contents, and then verifies the *published* result over
+// HTTP: the pages GitHub renders, that every link on the Home page resolves,
+// and that the in-wiki anchor link targets a heading that exists. The pull
+// test then syncs the live wiki back into a scratch workspace and verifies
+// the inverse preprocess transforms.
+//
+// These tests write to the real wiki, so they only run when a token is
+// available AND we're either in GitHub Actions or explicitly opted in:
+//
+//   E2E=1 GITHUB_TOKEN=$(gh auth token) deno test -A tests/e2e.test.ts
+import {
+  assert,
+  assertEquals,
+  assertStringIncludes,
+} from "jsr:@std/assert@^1.0.0";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const CLI_PATH = join(ROOT, "cli.ts");
+
+const REPO = Deno.env.get("GITHUB_REPOSITORY") ??
+  "Andrew-Chen-Wang/github-wiki-action";
+// cli.ts pins blob links to GITHUB_SHA and falls back to HEAD outside CI.
+const SHA = Deno.env.get("GITHUB_SHA") ?? "HEAD";
+const BLOB_BASE = `https://github.com/${REPO}/blob/${SHA}`;
+const WIKI_BASE = `https://github.com/${REPO}/wiki`;
+
+function ghToken(): string {
+  const env = Deno.env.get("GITHUB_TOKEN") ?? Deno.env.get("GH_TOKEN");
+  if (env) return env;
+  try {
+    const out = new Deno.Command("gh", {
+      args: ["auth", "token"],
+      stdout: "piped",
+      stderr: "null",
+    }).outputSync();
+    if (out.success) return new TextDecoder().decode(out.stdout).trim();
+  } catch {
+    // gh isn't installed; fall through
+  }
+  return "";
+}
+
+const TOKEN = ghToken();
+const ENABLED = TOKEN !== "" &&
+  (Deno.env.get("GITHUB_ACTIONS") === "true" || Deno.env.get("E2E") === "1");
+
+async function git(cwd: string, ...args: string[]): Promise<string> {
+  const out = await new Deno.Command("git", {
+    args,
+    cwd,
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+  if (!out.success) {
+    throw new Error(
+      `git ${args.join(" ")} failed:\n${new TextDecoder().decode(out.stderr)}`,
+    );
+  }
+  return new TextDecoder().decode(out.stdout).trim();
+}
+
+// Runs cli.ts against the real wiki. HOME is sandboxed so the cli's global
+// git config writes don't leak into the host; everything else (PATH with the
+// real gh, GITHUB_* vars) is inherited.
+async function runCli(cwd: string, inputs: Record<string, string>) {
+  const home = await Deno.makeTempDir({ prefix: "wiki-e2e-home-" });
+  const out = await new Deno.Command(Deno.execPath(), {
+    args: ["run", "-A", CLI_PATH],
+    cwd,
+    env: {
+      HOME: home,
+      USERPROFILE: home,
+      XDG_CONFIG_HOME: join(home, ".config"),
+      INPUT_STRATEGY: "clone",
+      INPUT_REPOSITORY: REPO,
+      INPUT_GITHUB_SERVER_URL: "https://github.com",
+      INPUT_TOKEN: TOKEN,
+      INPUT_PATH: "wiki",
+      INPUT_COMMIT_MESSAGE: `Update wiki ${SHA} (e2e test)`,
+      INPUT_IGNORE: "",
+      INPUT_DRY_RUN: "false",
+      INPUT_PREPROCESS: "true",
+      INPUT_DISABLE_EMPTY_COMMITS: "false",
+      ...inputs,
+    },
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+  if (!out.success) {
+    throw new Error(
+      "cli.ts failed\n--- stdout ---\n" +
+        new TextDecoder().decode(out.stdout) +
+        "\n--- stderr ---\n" +
+        new TextDecoder().decode(out.stderr),
+    );
+  }
+}
+
+// GETs a URL like a wiki reader would, retrying transient failures.
+async function fetchOk(url: string): Promise<string> {
+  let lastStatus = 0;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    if (attempt > 0) await new Promise((r) => setTimeout(r, 2000 * attempt));
+    const res = await fetch(url);
+    const body = await res.text();
+    if (res.ok) return body;
+    lastStatus = res.status;
+    if (res.status < 429) break; // 4xx (except rate limit) won't heal
+  }
+  throw new Error(`GET ${url} failed with HTTP ${lastStatus}`);
+}
+
+Deno.test({
+  name: "e2e push: publishes the wiki and every Home page link resolves",
+  ignore: !ENABLED,
+  fn: async () => {
+    await runCli(ROOT, {});
+
+    // Clone the wiki back: the pushed tree must mirror the wiki/ source
+    // directory with README.md renamed to Home.md.
+    const clone = await Deno.makeTempDir({ prefix: "wiki-e2e-clone-" });
+    await git(
+      clone,
+      "clone",
+      "--depth=1",
+      `https://github.com/${REPO}.wiki.git`,
+      ".",
+    );
+    const sourceFiles = [...Deno.readDirSync(join(ROOT, "wiki"))]
+      .map((e) => (e.name === "README.md" ? "Home.md" : e.name))
+      .sort();
+    const wikiFiles = [...Deno.readDirSync(clone)]
+      .map((e) => e.name)
+      .filter((name) => name !== ".git")
+      .sort();
+    assertEquals(wikiFiles, sourceFiles);
+
+    // Preprocess transforms: page links went bare (#8) and repo-file links
+    // became blob URLs pinned to this commit (#78).
+    const home = await Deno.readTextFile(join(clone, "Home.md"));
+    assertStringIncludes(home, "(./another-page)");
+    assert(!home.includes("(./another-page.md)"), "page link kept .md");
+    assertStringIncludes(home, `${BLOB_BASE}/cli.ts`);
+    assertStringIncludes(home, `${BLOB_BASE}/tests/cli.test.ts`);
+
+    // Navigate every link on the published Home page: in-wiki links resolve
+    // relative to the wiki, blob links are absolute. All must load.
+    const links = [...home.matchAll(/\]\(([^)]+)\)/g)].map((m) => m[1]);
+    assert(links.length >= 4, `only found ${links.length} links on Home`);
+    for (const link of links) {
+      const path = link.split("#")[0];
+      if (!path) continue; // same-page anchor
+      assert(
+        path.startsWith("./") || path.startsWith("https://"),
+        `unexpected link on Home: ${link}`,
+      );
+      const target = path.startsWith("./")
+        ? `${WIKI_BASE}/${path.slice(2)}`
+        : path;
+      await fetchOk(target);
+    }
+
+    // The rendered Home page shows the blob link, and the in-wiki anchor
+    // link targets a heading that exists on the rendered destination page.
+    assertStringIncludes(await fetchOk(WIKI_BASE), `${BLOB_BASE}/cli.ts`);
+    assertStringIncludes(
+      await fetchOk(`${WIKI_BASE}/another-page`),
+      "some＿impꗝrtant＿stuff-",
+    );
+  },
+});
+
+Deno.test({
+  name: "e2e pull: syncs the live wiki back with inverse transforms",
+  ignore: !ENABLED,
+  fn: async () => {
+    // A scratch workspace standing in for a fresh actions/checkout, with a
+    // stale page that no longer exists in the wiki.
+    const workspace = await Deno.makeTempDir({ prefix: "wiki-e2e-pull-" });
+    await git(workspace, "init", "-q", "-b", "main");
+    await Deno.mkdir(join(workspace, "wiki"));
+    await Deno.writeTextFile(
+      join(workspace, "wiki", "Stale-Page.md"),
+      "deleted from the wiki",
+    );
+
+    await runCli(workspace, { INPUT_DIRECTION: "pull" });
+
+    // Inverse transforms: Home.md -> README.md, bare page links get their
+    // .md extension back (anchors preserved), absolute URLs untouched, and
+    // deleted pages are mirrored away.
+    const readme = await Deno.readTextFile(
+      join(workspace, "wiki", "README.md"),
+    );
+    assert(!existsSync(join(workspace, "wiki", "Home.md")), "Home.md kept");
+    assert(
+      !existsSync(join(workspace, "wiki", "Stale-Page.md")),
+      "stale page kept",
+    );
+    assert(existsSync(join(workspace, "wiki", "another-page.md")));
+    assertStringIncludes(readme, "(./another-page.md)");
+    assertStringIncludes(
+      readme,
+      "(./another-page.md#some＿impꗝrtant＿stuff-)",
+    );
+    assertStringIncludes(readme, `${BLOB_BASE}/cli.ts`);
+  },
+});

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -4,3 +4,7 @@ wiki. 🥳
 
 Check [this other page out](./another-page.md)! 
 [This section](./another-page.md#some＿impꗝrtant＿stuff-) is also pretty important
+
+Links to files in the repository, like [`cli.ts`](../cli.ts) or
+[the tests](/tests/cli.test.ts), turn into blob view URLs so they keep working
+from the wiki.


### PR DESCRIPTION
Closes #66, closes #67, closes #78.

## Push direction: repo-file links become blob URLs (#78)

The `preprocess` step now classifies each plain-path link by where it actually resolves:

- **Inside the wiki folder** → unchanged behavior from #8: `.md` links become bare page links (`./page.md#frag` → `./page#frag`, `README.md` → `Home`).
- **Elsewhere in the checked-out repository, and the file exists** → rewritten to `{server}/{repo}/blob/{sha}/{path}`, mirroring how GitHub resolves relative and `/`-rooted paths when rendering in-repo Markdown. Anchors/query strings and percent-encoded paths are preserved. Cross-repo publishing uses `GITHUB_REPOSITORY`/`GITHUB_SHA`, so links point at the source repo rather than the wiki's repo.
- **Dead links and external URLs** → left untouched.

`wiki/README.md` gains two repository-file links (relative `../cli.ts` and root-relative `/tests/cli.test.ts`) so this repo's live wiki demonstrates the transform.

## Pull direction: `direction: pull` (#66, #67)

A new `direction` input (default `push`) adds the wiki 👉 repo sync from #66 with the inverse link transform from #67. `pull` clones the wiki, applies the exact inverse of the push preprocess — `Home.md` → `README.md`, `./page` → `./page.md`, `./Home` → `./README.md`, anchors preserved — and mirrors the result into the `path` folder (deleted wiki pages disappear too). Nothing is committed or pushed to the repository, per the discussion in #66: pair it with a PR-creating action. The README documents a `gollum`-triggered workflow using `peter-evans/create-pull-request`.

## Testing

- 4 new integration tests (one #78 scenario covering relative/root-relative/encoded/dead/external/page/asset links; three pull scenarios incl. preprocess=false and dry-run) — 12/12 pass on Deno 2.8.3, `deno check` clean.
- New `test-action-pull` CI job pulls this repository's real wiki on ubuntu/windows/macos and verifies the inverse transforms.
- Ran both directions against the live wiki locally: the push dry-run reproduces the current wiki byte-for-byte (including the unicode-fragment link) plus the two new blob links, and the pull run round-trips the live wiki into an exact copy of the source `wiki/` folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NZ3LFshc4C8cp63fPst1yw

## Home/README no-clobber fix

Credit to [opensearch-project/opensearch-build](https://github.com/opensearch-project/opensearch-build)'s wiki for catching this: their `docs/` folder (synced with a pre-preprocess pin of this action) legitimately contains both `README.md` and `Home.md` as separate pages. The push preprocess used to rename `README.md` over the real `Home.md`, silently dropping a page — and pull mode had the mirrored bug. The rename in each direction now only happens when it doesn't overwrite an existing page, with the `README.md` ⇄ `Home` link mappings following suit. Verified by dry-running their full wiki through both directions (every page render-diffed against their live wiki) plus new regression tests.


## Behavior notes for release

- Unknown `direction` values now fail with `NotSupportedError` instead of silently pushing.
- Malformed page links with trailing junk after the extension (e.g. `page.md/extra`, `page.md:1`) are no longer rewritten; only well-formed `path(?query)(#fragment)` links are.
- The `.ron` extension is no longer treated as a page extension (GitHub has never rendered it).
- The env dump at startup now redacts credential-shaped variables instead of relying solely on runner secret masking.
- Subdirectory pages are now preprocessed too: since the wiki namespace is flat, cross-directory page links become bare page names (same-directory links keep their form) and the pull direction restores real file paths from an index of page names. Reference-style definitions are rewritten according to how they are referenced, and images pointing at repository files become `raw/` URLs (blob pages do not render inside images).

